### PR TITLE
Change changelog headings.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,11 +3,8 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
+<br/>
 ## [Unreleased]
-
-### Added
-- ProfileDose object built ontop of xarray. [@SimonBiggs](https://github.com/SimonBiggs).
 
 ### Breaking Changes
 - All uses of "dcm" in directory names, module names, function names, etc.
@@ -17,29 +14,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     - `coords_and_dose_from_dcm()` --> `coords_and_dose_from_dicom()`
     - `dcmfromdict()` --> `dicom_from_dict()`
     - `gamma_dcm()` --> `gamma_dicom()`
-- All uses of `dcm` as a variable name for storing a pydicom Dataset have been converted to `ds` to
+- MU Density related functions are no longer available under the `pymedphys.coll` package,
+  instead they are found within `pymedphys.mudensity` package.
+
+### New Features
+- ProfileDose object built ontop of xarray. [@SimonBiggs](https://github.com/SimonBiggs).
+
+### Bug Fixes
+- nil
+
+### Code Refactoring
+- All uses of `dcm` as a variable name for storing a PyDicom Dataset have been converted to `ds` to
   match PyDicom convention.
-- MU Density related functions are no longer available under the `pymedphys.coll` package, instead they are found within `pymedphys.mudensity` package.
 
-### Deprecated
+### Performance Improvements
 - nil
 
-### Removed
-- nil
-
-### Fixed
-- nil
-
-### Safety
-- nil
-
-### Security
-- nil
-
-
+<br/>
 ## [0.5.1] -- 2019/01/05
 
-### Added
+### New Features
 - Began keeping record of changes in `changelog.md`
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,6 @@
 All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 <br/>
 ## [Unreleased]
 
@@ -29,8 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Performance Improvements
 - nil
-
 <br/>
+
 ## [0.5.1] -- 2019/01/05
 
 ### New Features

--- a/src/pymedphys/dicom/_level2/dicom_anonymise.py
+++ b/src/pymedphys/dicom/_level2/dicom_anonymise.py
@@ -158,8 +158,8 @@ def anonymise_dicom(ds, delete_private_tags=True, tags_to_keep=None,
                          "SeriesTime",
                          "StationName",
                          "StudyDate",
-                         "StudyTime",
                          "StudyID",
+                         "StudyTime",
                          "Time",
                          "VerifyingObserverName"]
 

--- a/src/pymedphys/dicom/_level2/dicom_anonymise.py
+++ b/src/pymedphys/dicom/_level2/dicom_anonymise.py
@@ -68,9 +68,9 @@ def anonymise_dicom(ds, delete_private_tags=True, tags_to_keep=None,
 
     Raises
     ------
-    AssertionError
-        Raised if `ignore_unknown_tags` is set to False and unrecognised DICOM
-        tags are detected in `ds`
+    ValueError
+        Raised if `ignore_unknown_tags` is set to False and unrecognised,
+        non-private DICOM tags are detected in `ds`
     """
 
     if tags_to_keep is None:
@@ -93,73 +93,75 @@ def anonymise_dicom(ds, delete_private_tags=True, tags_to_keep=None,
                 ds[tag].keyword
                 for tag in unknown_tags]
 
-            raise AssertionError(
+            raise ValueError(
                 "At least one of the non-private tags within your DICOM file "
-                "is not "
-                "within PyMedPhys's copy of the DICOM dictionary. If this is "
-                "the case there is a small chance an introduced tag might be "
-                "identifying. The unrecognised tags are:\n\n{}\n\n"
-                "To ignore this error, pass a value of True to "
-                "`ignore_unknown_tags` within "
-                "`anonymise_dicom`. Please inform the creators of PyMedPhys "
-                "that the baseline DICOM dictionary is out of date.".format(
-                    unknown_tag_names))
+                "is not within PyMedPhys's copy of the DICOM dictionary. It is "
+                "possible that one or more of these tags contain identifying "
+                "information. The unrecognised tags are:\n\n{}\n\n To ignore "
+                "this error, pass `ignore_unknown_tags=True` to "
+                "`anonymise_dicom()`. Please inform the creators of PyMedPhys "
+                "that the baseline DICOM dictionary is obsolete."
+                .format(unknown_tag_names))
 
-    tags_to_anonymise = ["StudyDate",
-                         "SeriesDate",
+    tags_to_anonymise = ["AccessionNumber",
                          "AcquisitionDate",
-                         "ContentDate",
-                         "OverlayDate",
-                         "CurveDate",
                          "AcquisitionDatetime",
-                         "StudyTime",
-                         "SeriesTime",
                          "AcquisitionTime",
+                         "ContentCreatorName",
+                         "ContentDate",
                          "ContentTime",
-                         "OverlayTime",
-                         "CurveTime",
-                         "AccessionNumber",
-                         "InstitutionName",
-                         "InstitutionAddress",
-                         "ReferringPhysicianName",
-                         "ReferringPhysicianAddress",
-                         "ReferringPhysicianTelephoneNumber",
-                         "ReferringPhysicianIdentificationSequence",
-                         "InstitutionalDepartmentName",
-                         "PhysiciansOfRecord",
-                         "PhysiciansOfRecordIdentificationSequence",
-                         "PerformingPhysicianName",
-                         "PerformingPhysicianIdentificationSequence",
-                         "NameOfPhysiciansReadingStudy",
-                         "PhysiciansReadingStudyIdentificationSequence",
-                         "OperatorsName",
-                         "PatientName",
-                         "PatientID",
-                         "IssuerOfPatientID",
-                         "PatientBirthDate",
-                         "PatientBirthTime",
-                         "PatientSex",
-                         "OtherPatientIDs",
-                         "OtherPatientNames",
-                         "PatientBirthName",
-                         "PatientAge",
-                         "PatientAddress",
-                         "PatientMotherBirthName",
                          "CountryOfResidence",
-                         "RegionOfResidence",
-                         "PatientTelephoneNumbers",
-                         "StudyID",
                          "CurrentPatientLocation",
-                         "PatientInstitutionResidence",
-                         "DateTime",
+                         "CurveDate",
+                         "CurveTime",
                          "Date",
-                         "Time",
-                         "PersonName",
+                         "DateTime",
                          "EthnicGroup",
-                         "StationName",
                          "InstanceCreationDate",
                          "InstanceCreationTime",
-                         "InstanceCreatorUID"]
+                         "InstanceCreatorUID",
+                         "InstitutionAddress",
+                         "InstitutionalDepartmentName",
+                         "InstitutionName",
+                         "IssuerOfPatientID",
+                         "NameOfPhysiciansReadingStudy",
+                         "OperatorsName",
+                         "OtherPatientIDs",
+                         "OtherPatientNames",
+                         "OverlayDate",
+                         "OverlayTime",
+                         "PatientAddress",
+                         "PatientAge",
+                         "PatientBirthDate",
+                         "PatientBirthName",
+                         "PatientBirthTime",
+                         "PatientID",
+                         "PatientInstitutionResidence",
+                         "PatientMotherBirthName",
+                         "PatientName",
+                         "PatientSex",
+                         "PatientTelephoneNumbers",
+                         "PerformingPhysicianIdentificationSequence",
+                         "PerformingPhysicianName",
+                         "PersonName",
+                         "PhysiciansOfRecord",
+                         "PhysiciansOfRecordIdentificationSequence",
+                         "PhysiciansReadingStudyIdentificationSequence",
+                         "ReferringPhysicianAddress",
+                         "ReferringPhysicianIdentificationSequence",
+                         "ReferringPhysicianName",
+                         "ReferringPhysicianTelephoneNumber",
+                         "RegionOfResidence",
+                         "ReviewerName",
+                         "SecondaryReviewerName",
+                         "SeriesDate",
+                         "SeriesTime",
+                         "StationName",
+                         "StudyDate",
+                         "StudyTime",
+                         "StudyID",
+                         "Time",
+                         "VerifyingObserverName"]
 
     ds_out = copy.deepcopy(ds)
 


### PR DESCRIPTION
New headings, largely taken from `angular`, in (my preferred) order:

- Breaking Changes
- New Features
- Bug Fixes
- Code Refactoring
- Performance Improvements 

I'm thinking that we keep all headings there with 'nil' underneath for the **Unreleased** subheading, but delete headings with "nil" once a release is cut. What do you think?