### PR TITLE
RFR: Perform CLI tests in temp dirpath

### DIFF
--- a/packages/pymedphys_dicom/tests/test_anonymise.py
+++ b/packages/pymedphys_dicom/tests/test_anonymise.py
@@ -33,7 +33,6 @@ DATA_DIR = pjoin(HERE, 'data', 'anonymise')
 test_filepath = pjoin(DATA_DIR, "RP.almost_anonymised.dcm")
 test_anon_basename = \
     "RP.1.2.246.352.71.5.53598612033.430805.20190416135558_Anonymised.dcm"
-test_anon_filepath = pjoin(DATA_DIR, test_anon_basename)
 file_meta = read_file_meta_info(test_filepath)
 temp_dirpath = pjoin(DATA_DIR, 'temp_{}'.format(uuid4()))
 temp_filepath = pjoin(temp_dirpath, "test.dcm")
@@ -190,8 +189,8 @@ def test_anonymise_file():
 
         # Deletion of original file
         temp_basename = "{}_{}.dcm".format(
-            '.'.join(test_filepath.split('.')[:-1]),
-            uuid4())
+            '.'.join(test_filepath.split('.')[:-1]), uuid4())
+
         temp_filepath = pjoin(dirname(test_filepath), temp_basename)
         copyfile(test_filepath, temp_filepath)
 
@@ -247,93 +246,105 @@ def test_anonymise_directory():
 @pytest.mark.skipif('SUBPACKAGE' in os.environ, reason="Need to extract CLI out of subpackages")
 def test_anonymise_cli():
 
-    # Basic file anonymisation
-    assert not is_anonymised_file(test_filepath)
-    assert not exists(test_anon_filepath)
-
-    anon_file_command = ('pymedphys dicom anonymise'.split() + [test_filepath])
     try:
-        subprocess.check_call(anon_file_command)
-        assert is_anonymised_file(test_anon_filepath)
-        assert exists(test_filepath)
+        makedirs(temp_dirpath, exist_ok=True)
+        copyfile(test_filepath, temp_filepath)
+        temp_anon_filepath = pjoin(temp_dirpath, test_anon_basename)
+
+        # Basic file anonymisation
+        assert not is_anonymised_file(temp_filepath)
+        assert not exists(temp_anon_filepath)
+
+        anon_file_command = (
+            'pymedphys dicom anonymise'.split() +
+            [temp_filepath])
+        try:
+            subprocess.check_call(anon_file_command)
+            assert is_anonymised_file(temp_anon_filepath)
+            assert exists(temp_filepath)
+        finally:
+            remove_file(temp_anon_filepath)
+
+        # File anonymisation - preserve filenames
+        assert not is_anonymised_file(temp_filepath)
+
+        expected_anon_filepath = label_dicom_filepath_as_anonymised(
+            temp_filepath)
+        assert not exists(expected_anon_filepath)
+
+        anon_file_pres_command = ('pymedphys dicom anonymise -f'.split()
+                                  + [temp_filepath])
+        try:
+            subprocess.check_call(anon_file_pres_command)
+            assert is_anonymised_file(expected_anon_filepath)
+            assert exists(temp_filepath)
+        finally:
+            remove_file(expected_anon_filepath)
+
+        # File anonymisation - clear values
+        assert not is_anonymised_file(temp_filepath)
+        assert not exists(temp_anon_filepath)
+
+        anon_file_clear_command = ('pymedphys dicom anonymise -c'.split()
+                                   + [temp_filepath])
+        try:
+            subprocess.check_call(anon_file_clear_command)
+            assert is_anonymised_file(temp_anon_filepath)
+            assert pydicom.dcmread(temp_anon_filepath).PatientName == ''
+            assert exists(temp_filepath)
+        finally:
+            remove_file(temp_anon_filepath)
+
+        # File anonymisation - leave keywords unchanged
+        assert not is_anonymised_file(temp_filepath)
+        assert not exists(temp_anon_filepath)
+
+        anon_file_keep_command = ('pymedphys dicom anonymise'.split()
+                                  + [temp_filepath]
+                                  + '-k PatientName'.split())
+        try:
+            subprocess.check_call(anon_file_keep_command)
+            assert not is_anonymised_file(temp_anon_filepath)
+            ds = pydicom.dcmread(temp_anon_filepath)
+            ds.PatientName = "Anonymous"
+            assert is_anonymised_dataset(ds)
+            assert exists(temp_filepath)
+        finally:
+            remove_file(temp_anon_filepath)
+
+        # File anonymisation - private tag handling
+        assert not is_anonymised_file(temp_filepath)
+        assert not exists(temp_anon_filepath)
+
+        anon_file_private_command = ('pymedphys dicom anonymise -p'.split()
+                                     + [temp_filepath])
+        try:
+            subprocess.check_call(anon_file_private_command)
+            assert not is_anonymised_file(temp_anon_filepath)
+            assert is_anonymised_file(temp_anon_filepath,
+                                      ignore_private_tags=True)
+            assert exists(temp_filepath)
+        finally:
+            remove_file(temp_anon_filepath)
+
+        # TODO: File anonymisation - unknown tag handling
+        # # Calling a subprocess reloads BaselineDicomDictionary...
+
+        # Basic dir anonymisation
+        assert not is_anonymised_directory(DATA_DIR)
+        assert not exists(temp_anon_filepath)
+
+        anon_dir_command = ('pymedphys dicom anonymise'.split()
+                            + [temp_dirpath])
+        try:
+            subprocess.check_call(anon_dir_command)
+            assert is_anonymised_file(temp_anon_filepath)
+            assert exists(temp_filepath)
+        finally:
+            remove_file(temp_anon_filepath)
     finally:
-        remove_file(test_anon_filepath)
-
-    # File anonymisation - preserve filenames
-    assert not is_anonymised_file(test_filepath)
-
-    expected_anon_filepath = label_dicom_filepath_as_anonymised(test_filepath)
-    assert not exists(expected_anon_filepath)
-
-    anon_file_pres_command = ('pymedphys dicom anonymise -f'.split()
-                              + [test_filepath])
-    try:
-        subprocess.check_call(anon_file_pres_command)
-        assert is_anonymised_file(expected_anon_filepath)
-        assert exists(test_filepath)
-    finally:
-        remove_file(expected_anon_filepath)
-
-    # File anonymisation - clear values
-    assert not is_anonymised_file(test_filepath)
-    assert not exists(test_anon_filepath)
-
-    anon_file_clear_command = ('pymedphys dicom anonymise -c'.split()
-                               + [test_filepath])
-    try:
-        subprocess.check_call(anon_file_clear_command)
-        assert is_anonymised_file(test_anon_filepath)
-        assert pydicom.dcmread(test_anon_filepath).PatientName == ''
-        assert exists(test_filepath)
-    finally:
-        remove_file(test_anon_filepath)
-
-    # File anonymisation - leave keywords unchanged
-    assert not is_anonymised_file(test_filepath)
-    assert not exists(test_anon_filepath)
-
-    anon_file_keep_command = ('pymedphys dicom anonymise'.split()
-                              + [test_filepath]
-                              + '-k PatientName'.split())
-    try:
-        subprocess.check_call(anon_file_keep_command)
-        assert not is_anonymised_file(test_anon_filepath)
-        ds = pydicom.dcmread(test_anon_filepath)
-        ds.PatientName = "Anonymous"
-        assert is_anonymised_dataset(ds)
-        assert exists(test_filepath)
-    finally:
-        remove_file(test_anon_filepath)
-
-    # File anonymisation - private tag handling
-    assert not is_anonymised_file(test_filepath)
-    assert not exists(test_anon_filepath)
-
-    anon_file_private_command = ('pymedphys dicom anonymise -p'.split()
-                                 + [test_filepath])
-    try:
-        subprocess.check_call(anon_file_private_command)
-        assert not is_anonymised_file(test_anon_filepath)
-        assert is_anonymised_file(test_anon_filepath,
-                                  ignore_private_tags=True)
-        assert exists(test_filepath)
-    finally:
-        remove_file(test_anon_filepath)
-
-    # TODO: File anonymisation - unknown tag handling
-    # # Calling a subprocess reloads BaselineDicomDictionary...
-
-    # Basic dir anonymisation
-    assert not is_anonymised_directory(DATA_DIR)
-    assert not exists(test_anon_filepath)
-
-    anon_dir_command = ('pymedphys dicom anonymise'.split() + [DATA_DIR])
-    try:
-        subprocess.check_call(anon_dir_command)
-        assert is_anonymised_file(test_anon_filepath)
-        assert exists(test_filepath)
-    finally:
-        remove_file(test_anon_filepath)
+        remove_file(temp_filepath)
+        remove_dir(temp_dirpath)
 
 
 def test_tags_to_anonymise_in_dicom_dict_baseline():


### PR DESCRIPTION
Fixes #262 

I should've noticed this ages ago, since I've used them quite a bit for RAH projects, I'd just forgotten because it'd been a while since I set them up.

We ought to use `pytest.fixtures` to run pre- and post-testing code. E.g. see [`tmp_path `](https://docs.pytest.org/en/latest/tmpdir.html). It's perfect for making temp dirs and ensuring their deletion after testing, regardless of the testing outcome. Much cleaner than a million `try/finally`s, I think.

Maybe for another PR though - I'm going to be flat out with other things until next Tuesday... :(
