### PR TITLE
[MRG] Order change for choco install

### DIFF
--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -118,7 +118,7 @@ Git LFS, yarn, and graphviz like so:
 
 .. code:: bash
 
-    choco install git yarn nodejs graphviz.portable
+    choco install git nodejs yarn graphviz.portable
 
 
 


### PR DESCRIPTION
Change the order choco installs to prevent the following error message:

![image](https://user-images.githubusercontent.com/47580406/61835961-60f37580-aec1-11e9-90cb-0613c9ad956e.png)
