### PR TITLE
[MRG] Do not treat group length as unknown tag in DICOM anonymisation

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -148,6 +148,7 @@
         "json",
         "operator",
         "os",
+        "pprint",
         "re",
         "warnings"
       ]

--- a/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
+++ b/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
@@ -164,7 +164,7 @@ def anonymise_dataset(
             "of date, please raise an issue on GitHub at "
             "https://github.com/pymedphys/pymedphys/issues.".format(
                 printer.pformat(unknown_tags_to_print)
-        )
+            )
         )
 
     elif delete_unknown_tags:
@@ -524,7 +524,16 @@ def is_anonymised_directory(dirpath, ignore_private_tags=False):
 def non_private_tags_in_dicom_dataset(ds):
     """Return all non-private tags from a DICOM dataset.
     """
-    non_private_tags = [elem.tag for elem in ds if not elem.tag.is_private]
+
+    non_private_tags = []
+
+    for elem in ds:
+        if not elem.tag.is_private and not (
+            # Ignore retired Group Length elements
+            elem.tag.element == 0
+            and elem.tag.group > 6
+        ):
+            non_private_tags.append(elem.tag)
     return non_private_tags
 
 

--- a/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
+++ b/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
@@ -544,7 +544,9 @@ def unknown_tags_in_dicom_dataset(ds):
             are_non_private_tags_in_dict_baseline.append(False)
 
     unknown_tags = list(
-        non_private_tags_in_dataset[np.invert(are_non_private_tags_in_dict_baseline)]
+        non_private_tags_in_dataset[
+            np.invert(np.array(are_non_private_tags_in_dict_baseline, dtype=bool))
+        ]
     )
 
     return unknown_tags

--- a/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
+++ b/packages/pymedphys_dicom/src/pymedphys_dicom/dicom/anonymise.py
@@ -27,6 +27,7 @@ from copy import deepcopy
 from glob import glob
 import json
 from os.path import abspath, basename, dirname, isdir, isfile, join as pjoin
+import pprint
 
 import numpy as np
 import pydicom
@@ -144,7 +145,8 @@ def anonymise_dataset(
     unknown_tags = unknown_tags_in_dicom_dataset(ds_anon)
 
     if delete_unknown_tags is None and unknown_tags:
-        unknown_keywords = [ds_anon[tag].keyword for tag in unknown_tags]
+        unknown_tags_to_print = {hex(tag): ds_anon[tag].keyword for tag in unknown_tags}
+        printer = pprint.PrettyPrinter(width=30)
 
         raise ValueError(
             "At least one of the non-private tags within your DICOM "
@@ -160,7 +162,9 @@ def anonymise_dataset(
             "`delete_unknown_tags=False` to this function. Finally, "
             "if you suspect that the PyMedPhys DICOM dictionary is out "
             "of date, please raise an issue on GitHub at "
-            "https://github.com/pymedphys/pymedphys/issues.".format(unknown_keywords)
+            "https://github.com/pymedphys/pymedphys/issues.".format(
+                printer.pformat(unknown_tags_to_print)
+        )
         )
 
     elif delete_unknown_tags:
@@ -432,7 +436,9 @@ def is_anonymised_dataset(ds, ignore_private_tags=False):
         if elem.keyword in IDENTIFYING_KEYWORDS:
             dummy_value = get_anonymous_replacement_value(elem.keyword)
             if not elem.value in ("", [], dummy_value):
-                if elem.VR == "DS" and np.isclose(float(elem.value), float(dummy_value)):
+                if elem.VR == "DS" and np.isclose(
+                    float(elem.value), float(dummy_value)
+                ):
                     continue
                 else:
                     return False


### PR DESCRIPTION
So I came across a CT that contained a bunch of "Group Length" elements that were treated as unknown by our anonymisers. This triggered a few improvements in the first two commits here:

-   https://github.com/pymedphys/pymedphys/commit/e0eac3cb093f345e2b9571c64b10632d7948fcc4 improved printing of unknown tag information by including the hex tag number as well as the keyword. In my CT case, the keywords were empty strings and so it took some manual debugging to discover that the Group Length elements were the problem. Adding tag number helps here, I think.
- https://github.com/pymedphys/pymedphys/commit/f7f48ef9f6d9f77ba60f0262434f0d8eefcdde6a fixes another error I got where basically `numpy`'s `bool` doesn't always play nice with native Python `bool`.
- https://github.com/pymedphys/pymedphys/commit/342041a906a437e2016599af7ea645eb2a7deb92 addresses the idea that maybe Group Length elements shouldn't be considered "unknown". Strictly they are "known", just retired. [DICOM basically recommends that these elements be discarded](http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.2.html) and [`pydicom` itself actually does discard them, at least when writing to file](https://github.com/pydicom/pydicom/pull/595). We could just continue as is, since users can strictly just pass `ignore_unknown_tags=True` to the anonymisation functions. But since deletion of Group Lengths is usually happening anyway, maybe we ought not to treat them as "unknown"? It's debatable, and I don't have a strong opinion.