### PR TITLE
[MRG] Skip slow

### DIFF
--- a/app/src/python/tests/test_user_scripts.py
+++ b/app/src/python/tests/test_user_scripts.py
@@ -27,6 +27,7 @@ def temp_workingdir(tmpdir_factory):
     return workingdir
 
 
+@pytest.mark.slow
 def test_gamma_calc(temp_workingdir):
     os.chdir(temp_workingdir)
     scriptpath = os.path.join(USER_SCRIPTS, "gamma.py")
@@ -34,6 +35,7 @@ def test_gamma_calc(temp_workingdir):
     runpy.run_path(scriptpath)
 
 
+@pytest.mark.slow
 def test_mu_density_diff(temp_workingdir):
     os.chdir(temp_workingdir)
     scriptpath = os.path.join(USER_SCRIPTS, "mu-density-diff.py")

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,29 @@
 
 import os
 
+import pytest
+
+
+# https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
 
 def pytest_ignore_collect(path, config):
     """return True to prevent considering this path for collection.

--- a/packages/pymedphys/tests/delivery_data/test_deliverydata_trf_dicom_round_trip.py
+++ b/packages/pymedphys/tests/delivery_data/test_deliverydata_trf_dicom_round_trip.py
@@ -74,6 +74,7 @@ def loaded_dicom_gantry_angles(loaded_dicom_dataset):
     return get_gantry_angles_from_dicom(loaded_dicom_dataset)
 
 
+@pytest.mark.slow
 def test_fraction_group_number(loaded_dicom_dataset, logfile_delivery_data: Delivery):
     expected = FRACTION_GROUP
 
@@ -82,6 +83,7 @@ def test_fraction_group_number(loaded_dicom_dataset, logfile_delivery_data: Deli
     assert result == expected
 
 
+@pytest.mark.slow
 def test_get_metersets_from_delivery_data(
     logfile_delivery_data, loaded_dicom_dataset, loaded_dicom_gantry_angles
 ):
@@ -99,6 +101,7 @@ def test_get_metersets_from_delivery_data(
         raise
 
 
+@pytest.mark.slow
 def test_filter_cps(logfile_delivery_data):
     filtered = logfile_delivery_data.filter_cps()
 
@@ -106,6 +109,7 @@ def test_filter_cps(logfile_delivery_data):
         assert len(getattr(logfile_delivery_data, field)) != 0
 
 
+@pytest.mark.slow
 def test_round_trip_dd2dcm2dd(loaded_dicom_dataset, logfile_delivery_data: Delivery):
     original = logfile_delivery_data.filter_cps()
     template = loaded_dicom_dataset
@@ -129,6 +133,7 @@ def test_round_trip_dd2dcm2dd(loaded_dicom_dataset, logfile_delivery_data: Deliv
     )
 
 
+@pytest.mark.slow
 def test_round_trip_dcm2dd2dcm(loaded_dicom_dataset, loaded_dicom_gantry_angles):
     original = loaded_dicom_dataset
     delivery_data = Delivery.from_dicom(original, FRACTION_GROUP)
@@ -157,6 +162,7 @@ def test_round_trip_dcm2dd2dcm(loaded_dicom_dataset, loaded_dicom_gantry_angles)
     assert str(single_fraction_group) == str(processed)
 
 
+@pytest.mark.slow
 def test_mudensity_agreement(loaded_dicom_dataset, logfile_delivery_data):
     dicom_delivery_data = Delivery.from_dicom(loaded_dicom_dataset, FRACTION_GROUP)
 

--- a/packages/pymedphys_dicom/tests/test_anonymise.py
+++ b/packages/pymedphys_dicom/tests/test_anonymise.py
@@ -95,6 +95,7 @@ def _get_non_anonymous_replacement_value(keyword):
     return VR_NON_ANONYMOUS_REPLACEMENT_VALUE_DICT[vr]
 
 
+@pytest.mark.slow
 def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
 
     # Create dataset with one instance of every identifying keyword and
@@ -273,6 +274,7 @@ def test_anonymise_directory(tmp_path):
         remove_file(temp_anon_filepath)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(
     "SUBPACKAGE" in os.environ, reason="Need to extract CLI out of subpackages"
 )

--- a/packages/pymedphys_gamma/tests/gamma/test_agnew_mcgarry.py
+++ b/packages/pymedphys_gamma/tests/gamma/test_agnew_mcgarry.py
@@ -173,6 +173,7 @@ def test_local_gamma_0_25mm():
     )
 
 
+@pytest.mark.slow
 def test_multi_inputs():
     gamma = run_gamma(
         REF_VMAT_0_25mm,

--- a/packages/pymedphys_mudensity/tests/mudensity/test_mu_density_regression.py
+++ b/packages/pymedphys_mudensity/tests/mudensity/test_mu_density_regression.py
@@ -32,6 +32,8 @@
 
 import os
 
+import pytest
+
 import numpy as np
 
 from pymedphys_mudensity.mudensity import calc_mu_density

--- a/packages/pymedphys_mudensity/tests/mudensity/test_mu_density_regression.py
+++ b/packages/pymedphys_mudensity/tests/mudensity/test_mu_density_regression.py
@@ -43,6 +43,7 @@ DELIVERY_DATA_FILEPATH = os.path.abspath(
 )
 
 
+@pytest.mark.slow
 def test_regression():
     """The results of MU Density calculation should not change
     """

--- a/packages/pymedphys_pinnacle/tests/test_pinnacle.py
+++ b/packages/pymedphys_pinnacle/tests/test_pinnacle.py
@@ -92,6 +92,7 @@ def pinn(data):
     return pinn_objs
 
 
+@pytest.mark.slow
 def test_pinnacle(pinn):
 
     for p in pinn:
@@ -119,6 +120,7 @@ def find_corresponding_dicom(dcm):
     return None
 
 
+@pytest.mark.slow
 def test_ct(pinn):
 
     for p in pinn:
@@ -156,6 +158,7 @@ def test_ct(pinn):
                 assert np.allclose(exported_img, pinn_img, atol=0.00001)
 
 
+@pytest.mark.slow
 def test_struct(pinn):
 
     for p in pinn:
@@ -190,6 +193,7 @@ def test_struct(pinn):
         # TODO: Generate a mask for each contour and do a comparison of these
 
 
+@pytest.mark.slow
 def test_dose(pinn):
 
     for p in pinn:
@@ -231,6 +235,7 @@ def test_dose(pinn):
         assert np.allclose(exported_vol, pinn_vol, atol=0.01)
 
 
+@pytest.mark.slow
 def test_plan(pinn):
 
     for p in pinn:

--- a/packages/pymedphys_sphinxtheme/tests/test_builders.py
+++ b/packages/pymedphys_sphinxtheme/tests/test_builders.py
@@ -60,6 +60,7 @@ def build_all(root, **kwargs):
             yield ret
 
 
+@pytest.mark.slow
 def test_basic():
     for (app, status, warning) in build_all("test-basic"):
         assert app.env.get_doctree("index").traverse(addnodes.toctree)
@@ -111,6 +112,7 @@ def test_basic():
             )
 
 
+@pytest.mark.slow
 def test_empty():
     """Local TOC is showing, as toctree was empty"""
     for (app, status, warning) in build_all("test-empty"):
@@ -140,6 +142,7 @@ def test_empty():
             assert local_toc not in content
 
 
+@pytest.mark.slow
 def test_missing_toctree():
     """Local TOC is showing, as toctree was missing"""
     for (app, status, warning) in build_all("test-missing-toctree"):

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
 
     py37,docs,pylint: yarn install:test
 
-    py37: pytest -v --basetemp={envtmpdir} --junitxml=junit/.test.{envname}.xml []
+    py37: pytest -v --runslow --basetemp={envtmpdir} --junitxml=junit/.test.{envname}.xml []
 
     docs: yarn docs:netlify
 


### PR DESCRIPTION
Skip all slow tests. Any test that took longer than 1 s is being skipped by default. Only the Linux pipeline will run these tests.

Fixes https://github.com/pymedphys/pymedphys/issues/462

@Matthew-Jennings and @pchlap some of these tests I am skipping are yours, so probably worth having both of your approvals before merge.

I imagine there might be some value in the future in speeding up these tests that have been marked as slow. But for now, still having them run, but just on one pipeline, I think is the way to go.