### PR TITLE
Pinnacle export fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * nil -->
 
+## [Unreleased]
+
+### Breaking Changes
+
+* nil
+
+### New Features
+
+* nil
+
+### Bug Fixes
+
+* Fixed issue with Pinnacle Export Tool crashing when an image is missing from
+  the archive.
+
+### Code Refactoring
+
+* nil
+
+### Package Changes
+
+* nil
+
+### Performance Improvements
+
+* nil
+
+
 ## [0.30.0]
 
 ### Breaking changes

--- a/pymedphys/_data/hashes.json
+++ b/pymedphys/_data/hashes.json
@@ -25,6 +25,7 @@
   "original_dose_beam_4.dcm": "dea5e9206a5423d9388046f902e83f620b59686f",
   "paulking_test_data.zip": "057f8be65e80073e6e8c16c2b3e827d00aca79af",
   "pinnacle_test_data.zip": "1decbba6c3c2fe17f63d4087f5cceaf628bff1bd",
+  "pinnacle_test_data_no_image.zip": "8c57bf8c33db5ef47276b7a813a99e90740c1cc3",
   "profiler_test_data.zip": "18c682c1f49e2acb30c60d1fc04340ce276f903a",
   "pylinac_wlutz_regression_image.jpg": "8f46084c588d5474fe11c483025bca66078e88a5",
   "python-windows-64-embedded.zip": "e837b2de3a03112e6283e32ca1ab72d0c3bfc04f",

--- a/pymedphys/_data/urls.json
+++ b/pymedphys/_data/urls.json
@@ -25,6 +25,7 @@
   "tps_compare_dicom_files.zip": "https://zenodo.org/record/3870436/files/tps_compare_dicom_files.zip?download=1",
   "delivery_test_data.zip": "https://zenodo.org/record/3870436/files/delivery_test_data.zip?download=1",
   "pinnacle_test_data.zip": "https://zenodo.org/record/3870436/files/pinnacle_test_data.zip?download=1",
+  "pinnacle_test_data_no_image.zip": "https://zenodo.org/record/3903086/files/pinnacle_test_data_no_image.zip?download=1",
   "dummy-ct-and-struct.zip": "https://zenodo.org/record/3887286/files/dummy-ct-and-struct.zip?download=1",
   "alphanumeric-machine-id-icom.zip": "https://zenodo.org/record/3889005/files/alphanumeric-machine-id-icom.zip?download=1"
 }

--- a/pymedphys/labs/pinnacle/pinnacle.py
+++ b/pymedphys/labs/pinnacle/pinnacle.py
@@ -179,7 +179,10 @@ class PinnacleExport:
             self._images = []
             for image in self.patient_info["ImageSetList"]:
                 pi = PinnacleImage(self, self._path, image)
-                self._images.append(pi)
+
+                # Check that image info exists to ensure the image is really available
+                if pi.image_info:
+                    self._images.append(pi)
 
         return self._images
 
@@ -245,13 +248,11 @@ class PinnacleExport:
                 exported to.
         """
 
+        if not image and not series_uid:
+            self.logger.error("No image to export")
+
         for im in self.images:
             im_info = im.image_info[0]
-
-            if not im_info:
-                # If no ImageInfo is available then we can ignore this
-                continue
-
             im_suid = im_info["SeriesUID"]
             if len(series_uid) > 0 and im_suid == series_uid:
                 convert_image(im, export_path)

--- a/pymedphys/labs/pinnacle/pinnacle.py
+++ b/pymedphys/labs/pinnacle/pinnacle.py
@@ -247,6 +247,11 @@ class PinnacleExport:
 
         for im in self.images:
             im_info = im.image_info[0]
+
+            if not im_info:
+                # If no ImageInfo is available then we can ignore this
+                continue
+
             im_suid = im_info["SeriesUID"]
             if len(series_uid) > 0 and im_suid == series_uid:
                 convert_image(im, export_path)
@@ -261,6 +266,11 @@ class PinnacleExport:
 
         for i in self.images:
             image_header = i.image_header
+
+            if not image_header:
+                # If no ImageHeader is available then we can ignore this
+                continue
+
             self.logger.info(
                 "%s: %s %s",
                 image_header["modality"],

--- a/pymedphys/labs/pinnacle/pinnacle_image.py
+++ b/pymedphys/labs/pinnacle/pinnacle_image.py
@@ -126,6 +126,12 @@ class PinnacleImage:
             path_image_info = os.path.join(
                 self._path, f"ImageSet_{self._image['ImageSetID']}.ImageInfo"
             )
+
+            # Make sure the ImageInfo file really exists
+            if not os.path.exists(path_image_info):
+                self.logger.warning("ImageInfo path doesn't exist: %s", path_image_info)
+                return None
+
             self.logger.debug("Reading image data from: %s", path_image_info)
             self._image_info = pinn_to_dict(path_image_info)
 
@@ -145,6 +151,14 @@ class PinnacleImage:
             path_image_header = os.path.join(
                 self._path, f"ImageSet_{self._image['ImageSetID']}.header"
             )
+
+            # Make sure the ImageInfo file really exists
+            if not os.path.exists(path_image_header):
+                self.logger.warning(
+                    "ImageHeader path doesn't exist: %s", path_image_header
+                )
+                return None
+
             self.logger.debug("Reading image data from: %s", path_image_header)
             self._image_header = {}
             with open(path_image_header, "rt") as f:
@@ -175,6 +189,12 @@ class PinnacleImage:
             path_image_set = os.path.join(
                 self._path, f"ImageSet_{self._image['ImageSetID']}.ImageSet"
             )
+
+            # Make sure the ImageInfo file really exists
+            if not os.path.exists(path_image_set):
+                self.logger.warning("ImageSet path doesn't exist: %s", path_image_set)
+                return None
+
             self.logger.debug("Reading image data from: %s", path_image_set)
             self._image_set = pinn_to_dict(path_image_set)
 

--- a/pymedphys/labs/pinnacle/pinnacle_plan.py
+++ b/pymedphys/labs/pinnacle/pinnacle_plan.py
@@ -94,7 +94,7 @@ class PinnaclePlan:
                 self._primary_image = image
 
         if not self._primary_image:
-            self.logger.warn("Primary Image Not Available")
+            self.logger.warning("Primary Image Not Available")
 
     @property
     def logger(self):

--- a/pymedphys/labs/pinnacle/pinnacle_plan.py
+++ b/pymedphys/labs/pinnacle/pinnacle_plan.py
@@ -93,6 +93,9 @@ class PinnaclePlan:
             if image.image["ImageSetID"] == self.plan_info["PrimaryCTImageSetID"]:
                 self._primary_image = image
 
+        if not self._primary_image:
+            self.logger.warn("Primary Image Not Available")
+
     @property
     def logger(self):
         """Gets the configured logger.

--- a/pymedphys/tests/labs/pinnacle/test_pinnacle.py
+++ b/pymedphys/tests/labs/pinnacle/test_pinnacle.py
@@ -152,6 +152,7 @@ def test_ct(pinn):
 
 
 @pytest.mark.slow
+@pytest.mark.pydicom
 def test_struct(pinn):
 
     for p in pinn:
@@ -259,3 +260,23 @@ def test_plan(pinn):
 
         # TODO The RTPLAN export isn't fully functional yet, so we need
         # to test more as we add that functionality
+
+
+@pytest.mark.slow
+def test_missing_image():
+
+    zip_ref = ZipFile(
+        download.get_file_within_data_zip(
+            "pinnacle_test_data_no_image.zip", "pinnacle_test_no_image.zip"
+        ),
+        "r",
+    )
+    zip_ref.extractall(data_path)
+    zip_ref.close()
+
+    pinn_path = os.path.join(data_path, "Pt3", "Pinnacle", "Patient_7430")
+    pinn = PinnacleExport(pinn_path, None)
+
+    # There is no image to export, so this line should fail gracefully and simply output
+    # a warning to the logger
+    pinn.export_image(pinn.plans[0].primary_image, export_path=".")


### PR DESCRIPTION
Just a minor fix so that this tool can handle when an image is missing from a tar archive (seems be the case for us when phantom data is used, it is added as a sym link and doesn't get included in the tar archive).

@SimonBiggs Not sure if you want to me to merge changes like this myself or if you want me to assign a reviewer? Since this tool is still completely in labs then probably no review required?

I want to ensure I follow best practice properly, so would I update the change log for this? This change would then get rolled out with the next update, is that right? 0.31.0?