### PR TITLE
Added RN as file prefix for RT Ion Plan

### DIFF
--- a/pymedphys/_dicom/constants/core.py
+++ b/pymedphys/_dicom/constants/core.py
@@ -102,6 +102,7 @@ DICOM_SOP_CLASS_NAMES_MODE_PREFIXES = {
     "RT Image Storage": "RI",
     "RT Dose Storage": "RD",
     "RT Plan Storage": "RP",
+    "RT Ion Plan Storage": "RN",
     "RT Structure Set Storage": "RS",
     "Computed Radiography Image Storage": "CR",
     "Ultrasound Image Storage": "US",


### PR DESCRIPTION
The data I need to pseudonymise includes RT Ion Plans.
So... before I refactor anonymise so that it supports pseudonymisation to the greatest extent possible (DRY)
I need to be able to anonymise an RT Ion Plan.

In addition to passing
poetry run pymedphys dev tests
(same skipped tests and warnings as before I made the change...)

(after creating a setup.py and installing the package from the local )
pymedphys dicom anonymise -o TestRNAnon/ RN.mostly_pseudonymised.dcm 
RN.mostly_pseudonymised.dcm --> TestRNAnon/RN.1.2.826.0.1.3680043.10.188.4484482264202079986432620589628476654_Anonymised.dcm

(note the prefix was per the change to the code).
presumably the built in tests will convert a conventional RT Plan and show that it's prefix remains RP.

RN is the prefix used by MOSAIQ(tm) and ARIA(tm) and Eclipse(tm), so it is at least reasonably common.

