### PR TITLE
recurse through sequences in anonymise to find elements in the replacement list

### DIFF
--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -602,6 +602,13 @@ def _anonymise_tags(ds_anon, keywords_to_anonymise, replace_values):
                     replacement_value = ""
             setattr(ds_anon, keyword, replacement_value)
 
+    remaining_seq_only_list = [
+        x for x in ds_anon if (x.VR == "SQ" and x.name not in keywords_to_anonymise)
+    ]
+    for seq in remaining_seq_only_list:
+        for seq_item in seq.value:
+            _anonymise_tags(seq_item, keywords_to_anonymise, replace_values)
+
     return ds_anon
 
 


### PR DESCRIPTION
find sequences that were not in the replacement list and iterate through them
to find any elements in those sequences that are in the replacement list by
recursive call to _anonymise_tags
otherwise only the top level elements will get replaced.
e.g. Operators' Name (and Operator Identification Sequence) is frequently found in sequences and not at the top level 
RT (Ion) Beams Treatment Records
RT(Ion) Beams Session
>Treatment Session (Ion) Beam Sequence
>> (Ion) Control Point Delivery Sequennce
>>>Override Sequence
>>>> Operators' Name
>>>> Operator Identification Sequence
