### PR TITLE
added filename prefixes for treatment records

### DIFF
--- a/pymedphys/_dicom/constants/core.py
+++ b/pymedphys/_dicom/constants/core.py
@@ -111,6 +111,8 @@ DICOM_SOP_CLASS_NAMES_MODE_PREFIXES = {
     "Enhanced XA Image Storage": "XAE",
     "Nuclear Medicine Image Storage": "NM",
     "Secondary Capture Image Storage": "SC",
+    "RT Beams Treatment Record Storage": "RBT",
+    "RT Ion Beams Treatment Record Storage": "RIBT",
 }
 
 


### PR DESCRIPTION
added filename prefixes for:
RT Beams Treatment Record
RT Ion Beams Treatment Record

there is no common set of values for these to my knowledge
Need support for these to allow testing of anonymisation of these objects
which frequently contain Operator's Name in deeply buried sequences
Attempted to attach a gzipped copy of a sample RT Ion Beams Treatment Record (that has been through anonymisation).
The original data was of a phantom (no patient PHI, but the Operator was a real person... so I've just edited the anonymised file and put my name in for the Operator)
[RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_NotQuiteAnonymised.dcm.gz](https://github.com/pymedphys/pymedphys/files/4872673/RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_NotQuiteAnonymised.dcm.gz)
).
[RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_Anonymised.dcm.gz](https://github.com/pymedphys/pymedphys/files/4872624/RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_Anonymised.dcm.gz)

