### PR TITLE
recurse through sequences to check anonymisation of a dataset

### DIFF
--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -475,6 +475,16 @@ def is_anonymised_dataset(ds, ignore_private_tags=False):
                 "%s is private and private tags are not being ignored", elem.tag
             )
             return False
+        elif elem.VR == "SQ":
+            contents_are_anonymous = True
+            for seq in elem.value:
+                contents_are_anonymous = is_anonymised_dataset(seq, ignore_private_tags)
+                if not contents_are_anonymous:
+                    logging.info(
+                        "%s contained an element not considered to be anonymised",
+                        elem.name,
+                    )
+                    return False
 
     return True
 

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -30,6 +30,7 @@ from pymedphys._dicom.anonymise import (
     label_dicom_filepath_as_anonymised,
 )
 from pymedphys._dicom.constants import get_baseline_dicom_dict
+from pymedphys._dicom.create import dicom_dataset_from_dict
 from pymedphys._dicom.utilities import remove_file
 from pymedphys.dicom import anonymise as anonymise_dataset
 
@@ -109,6 +110,15 @@ def _get_non_anonymous_replacement_value(keyword):
     on its value representation (VR)"""
     vr = get_baseline_keyword_vr_dict()[keyword]
     return VR_NON_ANONYMOUS_REPLACEMENT_VALUE_DICT[vr]
+
+
+@pytest.mark.pydicom
+def test_anonymised_dataset_with_nested_name():
+    nested_name = dicom_dataset_from_dict(
+        {"OverrideSequence": [{"OperatorsName": "George"}]}
+    )
+
+    assert not is_anonymised_dataset(nested_name)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
For each sequence item in a sequence descend and identify any elements not considered to be anonymised.
Log the name of the sequence itself (for each sequence item).
Potential improvements would be to:
identify the index (in order of iteration) which sequence item(s) is/(are) involved
only log the sequence name once if there are multiple sequence items that are not considered to be anonymised.
 