### PR TITLE
add an RT Ion Beams Treatment Record as test fodder.

### DIFF
--- a/pymedphys/_data/hashes.json
+++ b/pymedphys/_data/hashes.json
@@ -81,6 +81,7 @@
   "tel-dicom-pairs.zip": "41a6e48bab9117f3bf0876fb4759378e7690dd7b",
   "tomo_mapcheck_test.txt": "93375b1b1a3eeee5f4810762545f42055f6b3b37",
   "tps_compare_dicom_files.zip": "d0d0a9676ae8ff8fca080611944fdafab5b6e83d",
+  "treatmentrecord-anonymisation.zip": "274f3e84af33887645a12f4256b96d35f1380909",
   "washed_out_bb.png": "06c7c32a1a4be6d2ebade915f28a998e3039c3a4",
   "water_phantom.zip": "b93ea8d89cf4030524ace0e67fa08082efd88776",
   "wlutz_arc_session.zip": "5db4f8becdaed134010b83a03fbd3a638745521c",

--- a/pymedphys/_data/urls.json
+++ b/pymedphys/_data/urls.json
@@ -27,5 +27,6 @@
   "pinnacle_test_data.zip": "https://zenodo.org/record/3940117/files/pinnacle_test_data.zip?download=1",
   "dummy-ct-and-struct.zip": "https://zenodo.org/record/3887286/files/dummy-ct-and-struct.zip?download=1",
   "alphanumeric-machine-id-icom.zip": "https://zenodo.org/record/3889005/files/alphanumeric-machine-id-icom.zip?download=1",
-  "rtplan-anonymisation.zip": "https://zenodo.org/record/3930533/files/rtplan-anonymisation.zip?download=1"
+  "rtplan-anonymisation.zip": "https://zenodo.org/record/3930533/files/rtplan-anonymisation.zip?download=1",
+  "treatmentrecord-anonymisation.zip": "https://zenodo.org/record/3931186/files/treatmentrecord-anonymisation.zip?download=1"
 }

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -117,6 +117,10 @@ def get_treatmentrecord_test_file_path():
     return test_treatmentrecord_file_path
 
 
+def get_test_filepaths():
+    return [get_rtplan_test_file_path(), get_treatmentrecord_test_file_path()]
+
+
 def _check_is_anonymised_dataset_file_and_dir(
     ds, tmp_path, test_file_path, anon_is_expected=True, ignore_private_tags=False
 ):
@@ -285,10 +289,8 @@ def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
 
 @pytest.mark.pydicom
 def test_anonymise_file():
-    test_file_path = get_rtplan_test_file_path()
-    _test_anonymise_file_at_path(test_file_path)
-    test_file_path = get_treatmentrecord_test_file_path()
-    _test_anonymise_file_at_path(test_file_path)
+    for test_file_path in get_test_filepaths():
+        _test_anonymise_cli_for_file(tmp_path, test_file_path)
 
 
 def _test_anonymise_file_at_path(test_file_path):
@@ -378,10 +380,8 @@ def test_anonymise_directory(tmp_path):
     "SUBPACKAGE" in os.environ, reason="Need to extract CLI out of subpackages"
 )
 def test_anonymise_cli(tmp_path):
-    test_file_path = get_rtplan_test_file_path()
-    _test_anonymise_cli_for_file(tmp_path, test_file_path)
-    test_file_path = get_treatmentrecord_test_file_path()
-    _test_anonymise_cli_for_file(tmp_path, test_file_path)
+    for test_file_path in get_test_filepaths():
+        _test_anonymise_cli_for_file(tmp_path, test_file_path)
 
 
 def _test_anonymise_cli_for_file(tmp_path, test_file_path):

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -44,7 +44,7 @@ TEST_ANON_BASENAME = (
 
 TEST_ANON_BASENAME_DICT = {
     "RP.almost_anonymised.dcm": "RP.1.2.246.352.71.5.53598612033.430805.20190416135558_Anonymised.dcm",
-    #    "RIBT.not_quite_anonymised.dcm": "RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_Anonymised.dcm",
+    "RIBT.not_quite_anonymised.dcm": "RIBT.1.2.392.200036.9123.100.30.310.200.12.1.20191125110540243000_Anonymised.dcm",
 }
 
 VR_NON_ANONYMOUS_REPLACEMENT_VALUE_DICT = {
@@ -83,6 +83,38 @@ def get_rtplan_test_file_path():
 def _download_rtplan_test_file():
     data_paths = download.zip_data_paths("rtplan-anonymisation.zip")
     return data_paths
+
+
+@functools.lru_cache()
+def _download_treatmentrecord_test_file():
+    data_paths = download.zip_data_paths("treatmentrecord-anonymisation.zip")
+    return data_paths
+
+
+@functools.lru_cache()
+def get_treatmentrecord_test_file_path():
+    """
+    Downloads the required test data from zenodo and returns a string representing
+    the absolute path including the test filename, appropriate to the platform/file system.
+    Because this function is wrapped with lru_cache, concurrently revised contents on zenodo will not
+    get pulled down while the python instance is running (the tests).
+    If you update the content on zenodo, re-run the tests.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    string:representing the absolute path including the test filename, appropriate to the platform/file system.
+
+    """
+    data_paths = _download_treatmentrecord_test_file()
+    test_treatmentrecord_path = next(
+        x for x in data_paths if x.name == "RIBT.not_quite_anonymised.dcm"
+    )
+    test_treatmentrecord_file_path = str(test_treatmentrecord_path.absolute())
+    return test_treatmentrecord_file_path
 
 
 def _check_is_anonymised_dataset_file_and_dir(
@@ -255,6 +287,8 @@ def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
 def test_anonymise_file():
     test_file_path = get_rtplan_test_file_path()
     _test_anonymise_file_at_path(test_file_path)
+    test_file_path = get_treatmentrecord_test_file_path()
+    _test_anonymise_file_at_path(test_file_path)
 
 
 def _test_anonymise_file_at_path(test_file_path):
@@ -345,6 +379,8 @@ def test_anonymise_directory(tmp_path):
 )
 def test_anonymise_cli(tmp_path):
     test_file_path = get_rtplan_test_file_path()
+    _test_anonymise_cli_for_file(tmp_path, test_file_path)
+    test_file_path = get_treatmentrecord_test_file_path()
     _test_anonymise_cli_for_file(tmp_path, test_file_path)
 
 

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -290,7 +290,7 @@ def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
 @pytest.mark.pydicom
 def test_anonymise_file():
     for test_file_path in get_test_filepaths():
-        _test_anonymise_cli_for_file(tmp_path, test_file_path)
+        _test_anonymise_file_at_path(test_file_path)
 
 
 def _test_anonymise_file_at_path(test_file_path):


### PR DESCRIPTION
The treatment record was added to Zenodo.
after testing the RT Plan, test the RT Ion Beams Treatment Record.
The purpose for adding the RT Ion Beams Treatment record includes:
1)  Make sure that RT Ion Beams Treatment Record could be processed by the
    anonymise module
2)  The RT Ion Beams Treatment Record contained sequences that contained
    elements requiring anonymisation.  The issue involving sequences was
    originally uncovered using the treatment record. It turned out
    that the test plan had a sequence containing an element requiring
    anonymisation as well, but the automated testing at the time didn't
    divluge that.  Manual testing of the treatment record did (where I knew
    there were sequence item contents requiring anonymisation)
3)  Referenced RT Plan Sequence with the referenced RT Plan SOP Instance UID
    is contained in the treatment record and will be used for testing
    pseudonymisation of UIDs.