### PR TITLE
assign dtype=object as per warnings for numpy array creation of ragged arrays

### DIFF
--- a/pymedphys/_experimental/fileformats/mephysto/api.py
+++ b/pymedphys/_experimental/fileformats/mephysto/api.py
@@ -48,8 +48,8 @@ def load_mephysto(filepath, output_to_file=False, output_directory=None, sort=Tr
     scan_depth = pull_mephysto_number("SCAN_DEPTH", file_contents)
 
     # Convert python lists into numpy arrays for easier use
-    distance = np.array(distance)
-    relative_dose = np.array(relative_dose)
+    distance = np.array(distance, dtype=object)
+    relative_dose = np.array(relative_dose, dtype=object)
     scan_curvetype = np.array(scan_curvetype)
     scan_depth = np.array(scan_depth)
 

--- a/pymedphys/tests/dicom/test_coords.py
+++ b/pymedphys/tests/dicom/test_coords.py
@@ -63,7 +63,7 @@ def run_xyz_function_tests(coord_system):
     for orient, dicom in test_ds_dict.items():
         test_xyz = coords.xyz_axes_from_dataset(dicom, coord_system)
 
-        expected_xyz[orient] = np.array(expected_xyz[orient])
+        expected_xyz[orient] = np.array(expected_xyz[orient], dtype=object)
 
         # These tests were being skipped in the previous code
         assert np.array_equal(test_xyz[0], expected_xyz[orient][0])


### PR DESCRIPTION
this might not be the desired approach if there is something deeper going on with the creation of the arrays or if there is significant impact in usage of the array with dtype=object assigned.
However, the warning during unit testing is clear that this code will fail to build/run in a near future version of numpy without some kind of change.
I just got tired of seeing the warnings while in a tight modify/unit test cycle