### PR TITLE
Use strategy to anonymise

### DIFF
--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -14,7 +14,7 @@
 
 import functools
 
-import pydicom
+from pymedphys._imports import pydicom
 
 from pymedphys._dicom.constants import PYMEDPHYS_ROOT_UID
 

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2020 Stuart Swerdloff, Matthew Jennings, Simon Biggs
-
+# Copyright (C) 2020 Stuart Swerdloff
+# Copyright (C) 2018 Matthew Jennings, Simon Biggs
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -56,9 +56,12 @@ def _get_vr_anonymous_hardcode_replacement_value(current_value, value_representa
     return get_vr_anonymous_replacement_value_dict()[value_representation]
 
 
-ANONYMISATION_HARDCODE_DISPATCH = {
-    key: functools.partial(
-        _get_vr_anonymous_hardcode_replacement_value, value_representation=key
-    )
-    for key in get_vr_anonymous_replacement_value_dict().keys()
-}
+@functools.lru_cache(maxsize=1)
+def get_default_hardcode_dispatch():
+    ANONYMISATION_HARDCODE_DISPATCH = {
+        key: functools.partial(
+            _get_vr_anonymous_hardcode_replacement_value, value_representation=key
+        )
+        for key in get_vr_anonymous_replacement_value_dict().keys()
+    }
+    return ANONYMISATION_HARDCODE_DISPATCH

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Stuart Swerdloff
+# Copyright (C) 2020 Stuart Swerdloff, Simon Biggs
 # Copyright (C) 2018 Matthew Jennings, Simon Biggs
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ def get_vr_anonymous_replacement_value_dict():
     return VR_ANONYMOUS_REPLACEMENT_VALUE_DICT
 
 
-def _get_vr_anonymous_hardcode_replacement_value(value_representation, current_value):
+def _get_vr_anonymous_hardcode_replacement_value(current_value, value_representation):
     """A single dispatch function that is used for any VR with the current_value of the element ignored
     This is the default for the replacement strategy
     """
@@ -56,97 +56,30 @@ def _get_vr_anonymous_hardcode_replacement_value(value_representation, current_v
     return get_vr_anonymous_replacement_value_dict()[value_representation]
 
 
-def _get_AE_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("AE", current_value)
+DISPATCH_KEYS_TO_OVERRIDE = [
+    "AE",
+    "AS",
+    "CS",
+    "DA",
+    "DS",
+    "DT",
+    "LO",
+    "LT",
+    "OB",
+    "OB or OW",
+    "OW",
+    "PN",
+    "SH",
+    "SQ",
+    "ST",
+    "TM",
+    "UI",
+    "US",
+]
 
-
-def _get_AS_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("AS", current_value)
-
-
-def _get_CS_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("CS", current_value)
-
-
-def _get_DA_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("DA", current_value)
-
-
-def _get_DS_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("DS", current_value)
-
-
-def _get_DT_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("DT", current_value)
-
-
-def _get_LO_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("LO", current_value)
-
-
-def _get_LT_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("LT", current_value)
-
-
-def _get_OB_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("OB", current_value)
-
-
-def _get_OB_or_OW_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("OB or OW", current_value)
-
-
-def _get_OW_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("OW", current_value)
-
-
-def _get_PN_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("PN", current_value)
-
-
-def _get_SH_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("SH", current_value)
-
-
-def _get_SQ_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("SQ", current_value)
-
-
-def _get_ST_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("ST", current_value)
-
-
-def _get_TM_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("TM", current_value)
-
-
-def _get_UI_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("UI", current_value)
-
-
-def _get_US_anonymous_hardcode_replacement_value(current_value):
-    return _get_vr_anonymous_hardcode_replacement_value("US", current_value)
-
-
-ANONYMISATION_HARDCODE_DISPATCH = dict(
-    {
-        "AE": _get_AE_anonymous_hardcode_replacement_value,
-        "AS": _get_AS_anonymous_hardcode_replacement_value,
-        "CS": _get_CS_anonymous_hardcode_replacement_value,
-        "DA": _get_DA_anonymous_hardcode_replacement_value,
-        "DS": _get_DS_anonymous_hardcode_replacement_value,
-        "DT": _get_DT_anonymous_hardcode_replacement_value,
-        "LO": _get_LO_anonymous_hardcode_replacement_value,
-        "LT": _get_LT_anonymous_hardcode_replacement_value,
-        "OB": _get_OB_anonymous_hardcode_replacement_value,
-        "OB or OW": _get_OB_or_OW_anonymous_hardcode_replacement_value,
-        "OW": _get_OW_anonymous_hardcode_replacement_value,
-        "PN": _get_PN_anonymous_hardcode_replacement_value,
-        "SH": _get_SH_anonymous_hardcode_replacement_value,
-        "SQ": _get_SQ_anonymous_hardcode_replacement_value,
-        "ST": _get_ST_anonymous_hardcode_replacement_value,
-        "TM": _get_TM_anonymous_hardcode_replacement_value,
-        "UI": _get_UI_anonymous_hardcode_replacement_value,
-        "US": _get_US_anonymous_hardcode_replacement_value,
-    }
-)
+ANONYMISATION_HARDCODE_DISPATCH = {
+    key: functools.partial(
+        _get_vr_anonymous_hardcode_replacement_value, value_representation=key
+    )
+    for key in DISPATCH_KEYS_TO_OVERRIDE
+}

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import logging
 
 from pymedphys._imports import pydicom
 
@@ -45,12 +46,13 @@ def get_vr_anonymous_replacement_value_dict():
     return VR_ANONYMOUS_REPLACEMENT_VALUE_DICT
 
 
-def _get_vr_anonymous_hardcode_replacement_value(
-    value_representation, current_value=None
-):
+def _get_vr_anonymous_hardcode_replacement_value(value_representation, current_value):
     """A single dispatch function that is used for any VR with the current_value of the element ignored
     This is the default for the replacement strategy
     """
+    if current_value is None:
+        logging.debug("Replacing empty value with hardcoded anonymisation value")
+
     return get_vr_anonymous_replacement_value_dict()[value_representation]
 
 

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2020 Stuart Swerdloff, Matthew Jennings, Simon Biggs
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+
+import pydicom
+
+from pymedphys._dicom.constants import PYMEDPHYS_ROOT_UID
+
+
+@functools.lru_cache(maxsize=1)
+def get_vr_anonymous_replacement_value_dict():
+    VR_ANONYMOUS_REPLACEMENT_VALUE_DICT = {
+        "AE": "Anonymous",
+        "AS": "100Y",
+        "CS": "ANON",
+        "DA": "20190303",
+        "DS": "12345678.9",
+        "DT": "20190303000900.000000",
+        "LO": "Anonymous",
+        "LT": "Anonymous",
+        "OB": (0).to_bytes(2, "little"),
+        "OB or OW": (0).to_bytes(2, "little"),
+        "OW": (0).to_bytes(2, "little"),
+        "PN": "Anonymous",
+        "SH": "Anonymous",
+        "SQ": [pydicom.Dataset()],
+        "ST": "Anonymous",
+        "TM": "000900.000000",
+        "UI": PYMEDPHYS_ROOT_UID,
+        "US": 12345,
+    }
+
+    return VR_ANONYMOUS_REPLACEMENT_VALUE_DICT
+
+
+def _get_vr_anonymous_hardcode_replacement_value(
+    value_representation, current_value=None
+):
+    """A single dispatch function that is used for any VR with the current_value of the element ignored
+    This is the default for the replacement strategy
+    """
+    return get_vr_anonymous_replacement_value_dict()[value_representation]
+
+
+def _get_AE_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("AE", current_value)
+
+
+def _get_AS_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("AS", current_value)
+
+
+def _get_CS_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("CS", current_value)
+
+
+def _get_DA_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("DA", current_value)
+
+
+def _get_DS_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("DS", current_value)
+
+
+def _get_DT_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("DT", current_value)
+
+
+def _get_LO_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("LO", current_value)
+
+
+def _get_LT_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("LT", current_value)
+
+
+def _get_OB_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("OB", current_value)
+
+
+def _get_OB_or_OW_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("OB or OW", current_value)
+
+
+def _get_OW_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("OW", current_value)
+
+
+def _get_PN_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("PN", current_value)
+
+
+def _get_SH_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("SH", current_value)
+
+
+def _get_SQ_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("SQ", current_value)
+
+
+def _get_ST_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("ST", current_value)
+
+
+def _get_TM_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("TM", current_value)
+
+
+def _get_UI_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("UI", current_value)
+
+
+def _get_US_anonymous_hardcode_replacement_value(current_value):
+    return _get_vr_anonymous_hardcode_replacement_value("US", current_value)
+
+
+ANONYMISATION_HARDCODE_DISPATCH = dict(
+    {
+        "AE": _get_AE_anonymous_hardcode_replacement_value,
+        "AS": _get_AS_anonymous_hardcode_replacement_value,
+        "CS": _get_CS_anonymous_hardcode_replacement_value,
+        "DA": _get_DA_anonymous_hardcode_replacement_value,
+        "DS": _get_DS_anonymous_hardcode_replacement_value,
+        "DT": _get_DT_anonymous_hardcode_replacement_value,
+        "LO": _get_LO_anonymous_hardcode_replacement_value,
+        "LT": _get_LT_anonymous_hardcode_replacement_value,
+        "OB": _get_OB_anonymous_hardcode_replacement_value,
+        "OB or OW": _get_OB_or_OW_anonymous_hardcode_replacement_value,
+        "OW": _get_OW_anonymous_hardcode_replacement_value,
+        "PN": _get_PN_anonymous_hardcode_replacement_value,
+        "SH": _get_SH_anonymous_hardcode_replacement_value,
+        "SQ": _get_SQ_anonymous_hardcode_replacement_value,
+        "ST": _get_ST_anonymous_hardcode_replacement_value,
+        "TM": _get_TM_anonymous_hardcode_replacement_value,
+        "UI": _get_UI_anonymous_hardcode_replacement_value,
+        "US": _get_US_anonymous_hardcode_replacement_value,
+    }
+)

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -56,30 +56,9 @@ def _get_vr_anonymous_hardcode_replacement_value(current_value, value_representa
     return get_vr_anonymous_replacement_value_dict()[value_representation]
 
 
-DISPATCH_KEYS_TO_OVERRIDE = [
-    "AE",
-    "AS",
-    "CS",
-    "DA",
-    "DS",
-    "DT",
-    "LO",
-    "LT",
-    "OB",
-    "OB or OW",
-    "OW",
-    "PN",
-    "SH",
-    "SQ",
-    "ST",
-    "TM",
-    "UI",
-    "US",
-]
-
 ANONYMISATION_HARDCODE_DISPATCH = {
     key: functools.partial(
         _get_vr_anonymous_hardcode_replacement_value, value_representation=key
     )
-    for key in DISPATCH_KEYS_TO_OVERRIDE
+    for key in get_vr_anonymous_replacement_value_dict().keys()
 }

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import functools
-import logging
 
 import pydicom
 

--- a/pymedphys/_dicom/anonymisation_strategy.py
+++ b/pymedphys/_dicom/anonymisation_strategy.py
@@ -58,10 +58,11 @@ def _get_vr_anonymous_hardcode_replacement_value(current_value, value_representa
 
 @functools.lru_cache(maxsize=1)
 def get_default_hardcode_dispatch():
+    keys = get_vr_anonymous_replacement_value_dict().keys()
     ANONYMISATION_HARDCODE_DISPATCH = {
         key: functools.partial(
             _get_vr_anonymous_hardcode_replacement_value, value_representation=key
         )
-        for key in get_vr_anonymous_replacement_value_dict().keys()
+        for key in keys
     }
     return ANONYMISATION_HARDCODE_DISPATCH

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2018 Matthew Jennings, Simon Biggs
+# Copyright (C) 2020 Stuart Swerdloff
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -690,7 +690,7 @@ def get_anonymous_replacement_value(
         #   elif ...
 
     if replacement_strategy is None:
-        replacement_strategy = anon.ANONYMISATION_HARDCODE_DISPATCH
+        replacement_strategy = anon.get_default_hardcode_dispatch()
     replacement_value = replacement_strategy[vr](current_value)
 
     return replacement_value

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -642,9 +642,26 @@ def _filter_identifying_keywords(keywords_to_leave_unchanged):
     return keywords_filtered
 
 
-def get_anonymous_replacement_value(keyword):
-    """Get an appropriate dummy anonymisation value for a DICOM element
+def get_anonymous_replacement_value(
+    keyword, current_value=None, replacement_strategy=None
+):
+    """Get an appropriate anonymisation value for a DICOM element
     based on its value representation (VR)
+    Parameters
+    ----------
+    keyword: text string that is the pydicom name for the DICOM attribute/element
+
+    current_value: optional, the value that is currently assigned to the element
+
+    replacement_strategy: optional, a dispatch dictionary whose keys are the text representation
+    of the VR of the element, and whose values are function references that take the current value
+    of the element.
+
+    Returns
+    -------
+    A value that is a suitable replacement for the element whose attributes are identified by the keyword
+
     """
     vr = get_baseline_keyword_vr_dict()[keyword]
-    return get_vr_anonymous_replacement_value_dict()[vr]
+    replacement_value = get_vr_anonymous_replacement_value_dict()[vr]
+    return replacement_value

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -69,6 +69,10 @@ def get_vr_anonymous_replacement_value_dict():
     return VR_ANONYMOUS_REPLACEMENT_VALUE_DICT
 
 
+def get_vr_anonymous_hardcode_replacement_value(value_representation):
+    return get_vr_anonymous_replacement_value_dict()[value_representation]
+
+
 def label_dicom_filepath_as_anonymised(filepath):
     basename_anon = "{}_Anonymised.dcm".format(
         ".".join(basename(filepath).split(".")[:-1])

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import functools
 import json
 import logging
 import os.path
@@ -29,7 +28,6 @@ from pymedphys._imports import pydicom
 from pymedphys._dicom import anonymisation_strategy as anon
 from pymedphys._dicom.constants import (
     DICOM_SOP_CLASS_NAMES_MODE_PREFIXES,
-    PYMEDPHYS_ROOT_UID,
     NotInBaselineError,
     get_baseline_dict_entry,
     get_baseline_keyword_vr_dict,

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -658,8 +658,8 @@ def get_anonymous_replacement_value(
         )
         #   elif ...
 
-    if replacement_strategy is not None:
-        replacement_value = replacement_strategy[vr](current_value)
-    else:
-        replacement_value = anon.ANONYMISATION_HARDCODE_DISPATCH[vr](current_value)
+    if replacement_strategy is None:
+        replacement_strategy = anon.ANONYMISATION_HARDCODE_DISPATCH
+    replacement_value = replacement_strategy[vr](current_value)
+
     return replacement_value

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2018 Matthew Jennings, Simon Biggs
 # Copyright (C) 2020 Stuart Swerdloff
+# Copyright (C) 2018 Matthew Jennings, Simon Biggs
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pymedphys/_dicom/anonymise.py
+++ b/pymedphys/_dicom/anonymise.py
@@ -618,9 +618,7 @@ def _filter_identifying_keywords(keywords_to_leave_unchanged):
 
 
 def get_anonymous_replacement_value(
-    keyword,
-    current_value=None,
-    replacement_strategy=anon.ANONYMISATION_HARDCODE_DISPATCH,
+    keyword, current_value=None, replacement_strategy=None
 ):
     """Get an appropriate anonymisation value for a DICOM element
     based on its value representation (VR)
@@ -662,5 +660,5 @@ def get_anonymous_replacement_value(
     if replacement_strategy is not None:
         replacement_value = replacement_strategy[vr](current_value)
     else:
-        replacement_value = anon.get_vr_anonymous_replacement_value_dict()[vr]
+        replacement_value = anon.ANONYMISATION_HARDCODE_DISPATCH[vr](current_value)
     return replacement_value


### PR DESCRIPTION
This is a design proposal:
instead of hardcoding a specific anonymisation approach (albeit with a few control variables that offer variations on the theme), explicitly specify a strategy for doing so.
That way, if someone has a different strategy for anonymisation, they can provide it (an inversion of control style approach).
I have not made modifications to the calling stack to provide the mechanism for passing in an alternative strategy yet.
I just wanted to show the idea (and invoke it by default to ensure it got tested by the unit/automatic tests) with a minimum of code.
By itself, this is a very inefficient way of doing what was already being done (adds two levels of indirection), but with this approach, one gains the flexibility to implement pseudonymisation (as an alternative anonymisation strategy).

Note that this also identifies a TODO that is separate from the strategy design discussion, which is appropriate handling of VR of CS where "ANON" or "" might break interoperability, or worse, DICOM conformance.