### PR TITLE
Disable pylint hint regarding dict iter

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -21,7 +21,8 @@ disable =
     ungrouped-imports,
     import-outside-toplevel,
     no-else-return,
-    unbalanced-tuple-unpacking
+    unbalanced-tuple-unpacking,
+    consider-iterating-dictionary
 
 
 [FORMAT]


### PR DESCRIPTION
@sjswerdloff, if there's something in pylint that we think shouldn't be flagged we can add it to the following list. What do you think about this change?