### PR TITLE
Leave empty values alone during anonymisation

### DIFF
--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -607,9 +607,14 @@ def _anonymise_tags(
     for keyword in keywords_to_anonymise:
         if hasattr(ds_anon, keyword):
             if replace_values:
+                if ds_anon[keyword].value in ("", None, []):
+                    logging.debug(
+                        f"{keyword} has value of empty list, None or empty string, no need to modify to anonymise"
+                    )
+                    continue
                 replacement_value = get_anonymous_replacement_value(
                     keyword,
-                    current_value=ds_anon[keyword],
+                    current_value=ds_anon[keyword].value,
                     replacement_strategy=replacement_strategy,
                 )
             else:

--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -609,7 +609,8 @@ def _anonymise_tags(
             if replace_values:
                 if ds_anon[keyword].value in ("", None, []):
                     logging.debug(
-                        f"{keyword} has value of empty list, None or empty string, no need to modify to anonymise"
+                        "%s has value of empty list, None or empty string, no need to modify to anonymise",
+                        keyword,
                     )
                     continue
                 replacement_value = get_anonymous_replacement_value(

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -161,6 +161,14 @@ def test_anonymised_dataset_with_nested_name():
     assert not is_anonymised_dataset(nested_name)
 
 
+@pytest.mark.pydicom
+def test_anonymised_dataset_with_empty_patient_sex():
+    blank_sex_ds = dicom_dataset_from_dict({"PatientSex": None})
+    assert is_anonymised_dataset(blank_sex_ds)
+    hardcode_replace_ds = anonymise_dataset(blank_sex_ds)
+    assert hardcode_replace_ds["PatientSex"].value is None
+
+
 @pytest.mark.slow
 @pytest.mark.pydicom
 def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):


### PR DESCRIPTION
closes issue #963 
added test that exposes the issue
added small block of code to continue past an identifying element that has an empty(-ish) value, and include debug level logging that this is happening.