### PR TITLE
Allow alternative identifying keywords

### DIFF
--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os.path
 import pprint
-from copy import deepcopy
+from copy import copy, deepcopy
 from glob import glob
 from os.path import abspath, basename, dirname, isdir, isfile
 from os.path import join as pjoin
@@ -42,10 +42,14 @@ IDENTIFYING_KEYWORDS_FILEPATH = pjoin(HERE, "identifying_keywords.json")
 
 
 @functools.lru_cache()
-def get_default_identifying_keywords():
+def _get_default_identifying_keywords():
     with open(IDENTIFYING_KEYWORDS_FILEPATH) as infile:
         IDENTIFYING_KEYWORDS = json.load(infile)
     return list(IDENTIFYING_KEYWORDS)
+
+
+def get_default_identifying_keywords():
+    return copy(_get_default_identifying_keywords())
 
 
 def label_dicom_filepath_as_anonymised(filepath):

--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -113,6 +113,12 @@ def anonymise_dataset(  # pylint: disable = inconsistent-return-statements
     copy_dataset : ``bool``, optional
         If ``True``, then a copy of ``ds`` is returned.
 
+    replacement_strategy: ``dict`` (keys are VR, value is dispatch function), optional
+        If left as the default value of ``None``, the hardcode replacement strategy is used.
+
+    alternative_identifying_keywords: ``list``, optional
+        If left as None, the default values for/list of identifying keywords are used
+
     Returns
     -------
     ds_anon : ``pydicom.dataset.Dataset``
@@ -243,6 +249,12 @@ def anonymise_file(
         set to ``False``, these tags are simply ignored. Pass ``False``
         with caution, since unrecognised tags may contain identifying
         information.
+
+    replacement_strategy: ``dict`` (keys are VR, value is dispatch function), optional
+        If left as the default value of ``None``, the hardcode replacement strategy is used.
+
+    alternative_identifying_keywords: ``list``, optional
+        If left as None, the default values for/list of identifying keywords are used
     """
     dicom_filepath = str(dicom_filepath)
 
@@ -348,6 +360,12 @@ def anonymise_directory(
         set to ``False``, these tags are simply ignored. Pass ``False``
         with caution, since unrecognised tags may contain identifying
         information.
+
+    replacement_strategy: ``dict`` (keys are VR, value is dispatch function), optional
+        If left as the default value of ``None``, the hardcode replacement strategy is used.
+
+    alternative_identifying_keywords: ``list``, optional
+        If left as None, the default values for/list of identifying keywords are used
     """
     dicom_dirpath = str(dicom_dirpath)
 

--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -683,7 +683,7 @@ def _filter_identifying_keywords(
     if identifying_keywords is None:
         keywords_filtered = get_default_identifying_keywords()
     else:
-        keywords_filtered = identifying_keywords
+        keywords_filtered = copy(identifying_keywords)
 
     for keyword in keywords_to_leave_unchanged:
         try:

--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -45,11 +45,11 @@ IDENTIFYING_KEYWORDS_FILEPATH = pjoin(HERE, "identifying_keywords.json")
 def _get_default_identifying_keywords():
     with open(IDENTIFYING_KEYWORDS_FILEPATH) as infile:
         IDENTIFYING_KEYWORDS = json.load(infile)
-    return list(IDENTIFYING_KEYWORDS)
+    return tuple(IDENTIFYING_KEYWORDS)
 
 
 def get_default_identifying_keywords():
-    return copy(_get_default_identifying_keywords())
+    return list(_get_default_identifying_keywords())
 
 
 def label_dicom_filepath_as_anonymised(filepath):

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -171,6 +171,27 @@ def test_anonymised_dataset_with_empty_patient_sex():
 
 @pytest.mark.slow
 @pytest.mark.pydicom
+def test_alternative_identifying_keywords():
+    default_keyword_list = list(IDENTIFYING_KEYWORDS)
+    alternative_keyword_list = list(default_keyword_list)
+    alternative_keyword_list.append("SOPInstanceUID")
+    test_file_path = get_treatmentrecord_test_file_path()
+    ds_test = pydicom.dcmread(test_file_path, force=True)
+    anon_private_filepath = anonymise_file(
+        test_file_path,
+        delete_private_tags=True,
+        alternative_identifying_keywords=alternative_keyword_list,
+    )
+    ds_anon = pydicom.dcmread(anon_private_filepath, force=True)
+    try:
+        assert is_anonymised_file(anon_private_filepath, ignore_private_tags=False)
+        assert ds_test["SOPInstanceUID"].value != ds_anon["SOPInstanceUID"].value
+    finally:
+        remove_file(anon_private_filepath)
+
+
+@pytest.mark.slow
+@pytest.mark.pydicom
 def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
 
     # Create dataset with one instance of every identifying keyword and

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -1,8 +1,10 @@
+import copy
 import functools
 import json
 import logging
 import os
 import subprocess
+import tempfile
 from copy import deepcopy
 from os.path import basename, dirname, exists
 from os.path import join as pjoin
@@ -20,11 +22,11 @@ import pydicom.tag
 from pymedphys._data import download
 from pymedphys._dicom import create
 from pymedphys._dicom.anonymise import (
-    IDENTIFYING_KEYWORDS,
     IDENTIFYING_KEYWORDS_FILEPATH,
     anonymise_directory,
     anonymise_file,
     get_baseline_keyword_vr_dict,
+    get_default_identifying_keywords,
     is_anonymised_dataset,
     is_anonymised_directory,
     is_anonymised_file,
@@ -172,22 +174,21 @@ def test_anonymised_dataset_with_empty_patient_sex():
 @pytest.mark.slow
 @pytest.mark.pydicom
 def test_alternative_identifying_keywords():
-    default_keyword_list = list(IDENTIFYING_KEYWORDS)
-    alternative_keyword_list = list(default_keyword_list)
+    alternative_keyword_list = copy.copy(get_default_identifying_keywords())
     alternative_keyword_list.append("SOPInstanceUID")
     test_file_path = get_treatmentrecord_test_file_path()
     ds_test = pydicom.dcmread(test_file_path, force=True)
-    anon_private_filepath = anonymise_file(
-        test_file_path,
-        delete_private_tags=True,
-        alternative_identifying_keywords=alternative_keyword_list,
-    )
-    ds_anon = pydicom.dcmread(anon_private_filepath, force=True)
-    try:
+    with tempfile.TemporaryDirectory() as output_directory:
+        anon_private_filepath = anonymise_file(
+            test_file_path,
+            output_filepath=output_directory,
+            delete_private_tags=True,
+            identifying_keywords=alternative_keyword_list,
+        )
+        ds_anon = pydicom.dcmread(anon_private_filepath, force=True)
+
         assert is_anonymised_file(anon_private_filepath, ignore_private_tags=False)
         assert ds_test["SOPInstanceUID"].value != ds_anon["SOPInstanceUID"].value
-    finally:
-        remove_file(anon_private_filepath)
 
 
 @pytest.mark.slow
@@ -198,7 +199,7 @@ def test_anonymise_dataset_and_all_is_anonymised_functions(tmp_path):
     # run basic anonymisation tests
     test_file_path = get_rtplan_test_file_path()
     ds = pydicom.dataset.Dataset()
-    for keyword in IDENTIFYING_KEYWORDS:
+    for keyword in get_default_identifying_keywords():
         # Ignore file meta elements for now
         tag = hex(pydicom.datadict.tag_for_keyword(keyword))
         if pydicom.tag.Tag(tag).group == 0x0002:
@@ -521,11 +522,13 @@ def _test_anonymise_cli_for_file(tmp_path, test_file_path):
 @pytest.mark.pydicom
 def test_tags_to_anonymise_in_dicom_dict_baseline(save_new_identifying_keywords=False):
     baseline_keywords = [val[4] for val in get_baseline_dicom_dict().values()]
-    assert set(IDENTIFYING_KEYWORDS).issubset(baseline_keywords)
+    assert set(get_default_identifying_keywords()).issubset(baseline_keywords)
 
     if save_new_identifying_keywords:
         with open(IDENTIFYING_KEYWORDS_FILEPATH, "w") as outfile:
-            json.dump(IDENTIFYING_KEYWORDS, outfile, indent=2, sort_keys=True)
+            json.dump(
+                get_default_identifying_keywords(), outfile, indent=2, sort_keys=True
+            )
 
         # TODO: Keywords to add if/when anonymisation of UIDs is implemented:
         # "AffectedSOPInstanceUID",


### PR DESCRIPTION
provide a mechanism for passing in an alternative list of identifying keywords.
The primary intended use is to allow passing in of a list that includes a variety of instance or instance reference UIDs so that said alternative list can be used for pseudonymisation.
