### PR TITLE
document pseudonymisation module api, use autoattribute to document the module variable

### DIFF
--- a/docs/ref/lib/experimental/index.rst
+++ b/docs/ref/lib/experimental/index.rst
@@ -17,3 +17,4 @@ Experimental Modules
     pinnacle
     profile
     sinogram
+    pseudonymisation

--- a/docs/ref/lib/experimental/pseudonymisation.rst
+++ b/docs/ref/lib/experimental/pseudonymisation.rst
@@ -1,0 +1,43 @@
+#####################
+Pseudonymisation Tool
+#####################
+
+.. contents::
+    :local:
+    :backlinks: entry
+
+
+.. automodule:: pymedphys.experimental.pseudonymisation
+    :no-members:
+
+*******
+Summary
+*******
+
+    Pseudonymisation provides a list of identifying keywords that includes UIDs
+    and an anonymisation strategy that utilises SHA3_256 to hash text which is then
+    encoded as base64, or for UIDs, converted to an integer appended to the PyMedPhys Org Root.  Dates are shifted consistently and ages are jittered.
+    The list of identifying keywords and the anonymisation strategy are passed in to
+    the (non-experimental) anonymisation module/functions.
+
+
+
+***
+API
+***
+
+.. autofunction:: pymedphys.experimental.pseudonymisation.get_default_pseudonymisation_keywords
+.. autoattribute:: pymedphys.experimental.pseudonymisation.pseudonymisation_dispatch
+    :annotation: strategy, i.e. dictionary of VR and function references for anonymisation to achieve pseudonymisation
+
+*******
+Example
+*******
+::
+
+    import pymedphys.experimental.pseudonymisation as pseudonymisation_api
+
+    anonymise_dataset(ds_input,
+        replacement_strategy=pseudonymisation_api.pseudonymisation_dispatch,
+        identifying_keywords=pseudonymisation_api.get_default_pseudonymisation_keywords(),
+    )


### PR DESCRIPTION
used annotate keyword to provide descriptive text instead of attempting
to use docstring or comment doc in the source for the module variable/attribute