### PR TITLE
Beginning of autocontouring project documentation

### DIFF
--- a/docs/background/autocontouring.rst
+++ b/docs/background/autocontouring.rst
@@ -20,7 +20,7 @@ Video goes here
 
 Details
 -------
-George!
+George! [1]_
 
 
 

--- a/docs/background/autocontouring.rst
+++ b/docs/background/autocontouring.rst
@@ -1,0 +1,42 @@
+======================
+Autocontouring Project
+======================
+
+.. contents::
+    :local:
+    :backlinks: entry
+
+
+Project aim
+-----------
+Foo bar
+
+
+Video Demonstrating Usage
+-------------------------
+Video goes here
+
+
+
+Details
+-------
+George!
+
+
+
+Basic Implementation
+--------------------
+Hi
+
+
+Advanced Implementation
+-----------------------
+Latis
+
+
+
+References
+----------
+
+.. [1] Cool N, et al. "Awesome neural networky stuffs"
+       *Really relevant Journal* 15.1 (2019): 60-67. https://doi.org/10.1002/acm2.12485

--- a/docs/background/autocontouring.rst
+++ b/docs/background/autocontouring.rst
@@ -1,6 +1,6 @@
-======================
-Autocontouring Project
-======================
+============================
+Automatic Contouring Project
+============================
 
 .. contents::
     :local:
@@ -9,12 +9,21 @@ Autocontouring Project
 
 Project aim
 -----------
-Foo bar
+
+The aim of this project is to have an automated machine record based delivery check between the treatment planning system, the information system, and the Linac for every patient and fraction.
+intent to act as a template for future work extending to other organs.
 
 
 Video Demonstrating Usage
 -------------------------
-Video goes here
+
+Best viewed at 720p resolution.
+
+.. raw:: html
+
+    <embed>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/fMCv5i6GJWI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </embed>
 
 
 
@@ -26,12 +35,14 @@ George! [1]_
 
 Basic Implementation
 --------------------
-Hi
+
+Details on how to implement the project into your own workflow will be provided once the code migrates from the experimental division of PyMedPhys into the main code base. Watch this space.
 
 
 Advanced Implementation
 -----------------------
-Latis
+
+Further details that expand the above implementation are to be detailed here. Watch this space.
 
 
 

--- a/docs/background/autocontouring.rst
+++ b/docs/background/autocontouring.rst
@@ -10,14 +10,26 @@ Automatic Contouring Project
 Project aim
 -----------
 
-The aim of this project is to have an automated machine record based delivery check between the treatment planning system, the information system, and the Linac for every patient and fraction.
-intent to act as a template for future work extending to other organs.
+Accurate contouring is a critical aspect of safe and effective
+treatment delivery in radiotherapy (RT). Current limitations in clinical
+practice include large intra and inter-observer variances (IOV), as well time
+delays in both contour generation and correction. This study designed and
+evaluated a 2D U-Net architecture with two primary aims:
+
+1) Automate a time consuming aspect of canine radiotherapy. Specifically, vacuum
+   bag segmentation has been reported to take approximately 30 minutes to
+   contour manually.
+
+2) Evaluate the ability of a 2D U-Net model to achieve expert level performance
+   as defined by Nikolov et al.'s surface dice similarity coefficient [1]_ with respect to IOV.
+
+The intent for this research is to act as a template for future work extending to other organs.
 
 
 Video Demonstrating Usage
 -------------------------
 
-Best viewed at 720p resolution.
+Best viewed at 720p+ resolution.
 
 .. raw:: html
 
@@ -29,8 +41,15 @@ Best viewed at 720p resolution.
 
 Details
 -------
-George! [1]_
 
+The research thesis developed during this software project is set to be released
+pending a final review. The work provides details of the model architecture, and
+evaluates performance under multiple loss functions. In addition, this
+work discusses the development of a second model designed to fulfil the need for
+contouring to become part of regular quality assurance testing.
+
+Consider joining the PyMedPhys `mailing list <https://groups.google.com/g/pymedphys?pli=1>`_ to
+be notified of release.
 
 
 Basic Implementation
@@ -39,15 +58,8 @@ Basic Implementation
 Details on how to implement the project into your own workflow will be provided once the code migrates from the experimental division of PyMedPhys into the main code base. Watch this space.
 
 
-Advanced Implementation
------------------------
-
-Further details that expand the above implementation are to be detailed here. Watch this space.
-
-
-
 References
 ----------
 
-.. [1] Cool N, et al. "Awesome neural networky stuffs"
-       *Really relevant Journal* 15.1 (2019): 60-67. https://doi.org/10.1002/acm2.12485
+.. [1] Nikolov et al. "Deep learning to achieve clinically applicable segmentation of head
+    and neck anatomy for radiotherapy." (2018): https://arxiv.org/pdf/1809.04430.pdf

--- a/docs/background/index.rst
+++ b/docs/background/index.rst
@@ -2,5 +2,6 @@ Explanatory Documents Overview
 ==============================
 
 * :doc:`open-source-benefits`
+* :doc:`autocontouring`
 * :doc:`elekta-logfiles`
 * :doc:`file-structure`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,5 +55,6 @@ Overview
 
     background/index
     background/open-source-benefits
+    background/autocontouring
     background/elekta-logfiles
     background/file-structure

--- a/protyping/auto-segmentation/storage_and_inference_scp.py
+++ b/protyping/auto-segmentation/storage_and_inference_scp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import time
 from collections import deque
 


### PR DESCRIPTION
@matthewdeancooper can you clone this branch and run:

```bash
# install docs dependencies
poetry install -E docs

# build docs
poetry run pymedphys dev docs
```

Which will build the docs, which you can then browse by using something like https://docs.python.org/3/library/http.server.html.

Then you can see what the impact is of updating this file. If you can then update the document at https://github.com/pymedphys/pymedphys/blob/autocontouring-project/docs/background/autocontouring.rst we might be able to get it merged today. ...I'd rather not need to work on this on Saturday if possible :).

Cheers,
Simon