### PR TITLE
fix issue #1034, pseudonymisation crashes on data containing sequences

### DIFF
--- a/pymedphys/_dicom/anonymise/__init__.py
+++ b/pymedphys/_dicom/anonymise/__init__.py
@@ -737,6 +737,15 @@ def get_anonymous_replacement_value(
 
     if replacement_strategy is None:
         replacement_strategy = strategy.ANONYMISATION_HARDCODE_DISPATCH
-    replacement_value = replacement_strategy[vr](current_value)
+    try:
+        replacement_value = replacement_strategy[vr](current_value)
+    except KeyError:
+        logging.error(
+            "Unable to anonymise %s with VR %s, current value is %s",
+            keyword,
+            vr,
+            current_value,
+        )
+        raise
 
     return replacement_value

--- a/pymedphys/_experimental/pseudonymisation/__init__.py
+++ b/pymedphys/_experimental/pseudonymisation/__init__.py
@@ -43,9 +43,18 @@ def get_default_identifying_uids():
 
 @functools.lru_cache()
 def _get_default_pseudonymisation_keywords():
-    anon_keyword_set = set(get_default_identifying_keywords())
-    psuedo_uid_set = set(get_default_identifying_uids())
-    return tuple(anon_keyword_set.union(psuedo_uid_set))
+    anon_keyword_list = get_default_identifying_keywords()
+    # The preferred approach is to pseudonymise the contents
+    # of sequences, rather than operate on the sequence itself
+    #
+    # Eliminating the keywords that are sequences fixes issue #1034
+    # for default usage
+    identifying_keywords_less_sequences = [
+        x for x in anon_keyword_list if not x.endswith("Sequence")
+    ]
+    anon_keyword_set = set(identifying_keywords_less_sequences)
+    pseudo_uid_set = set(get_default_identifying_uids())
+    return tuple(anon_keyword_set.union(pseudo_uid_set))
 
 
 def get_default_pseudonymisation_keywords():

--- a/pymedphys/_experimental/pseudonymisation/strategy.py
+++ b/pymedphys/_experimental/pseudonymisation/strategy.py
@@ -327,7 +327,14 @@ def _pseudonymise_SH(value):
 
 
 def _pseudonymise_SQ(value):
-    return _pseudonymise_unchanged(value)
+    # returning an empty sequence addresses issue #1034,
+    # should the programmer choose to include a sequence
+    # in the list of identifying keywords.
+    # But the default list of identifying keywords from
+    # pseudonymisation has had sequences removed
+    # so that the contents will be pseudonymised rather
+    # than the sequences themselves
+    return [pydicom.Dataset()]
 
 
 def _pseudonymise_ST(value):
@@ -370,6 +377,7 @@ pseudonymisation_dispatch = dict(
         "PN": _pseudonymise_PN,
         "SH": _pseudonymise_SH,
         "ST": _pseudonymise_ST,
+        "SQ": _pseudonymise_SQ,
         "TM": _pseudonymise_TM,
         "UI": _pseudonymise_UI,
         "US": _pseudonymise_US,

--- a/pymedphys/_experimental/pseudonymisation/strategy.py
+++ b/pymedphys/_experimental/pseudonymisation/strategy.py
@@ -15,6 +15,7 @@
 import base64
 import datetime
 import hashlib
+import logging
 import random
 from decimal import Decimal, DecimalTuple
 
@@ -334,6 +335,10 @@ def _pseudonymise_SQ(value):
     # pseudonymisation has had sequences removed
     # so that the contents will be pseudonymised rather
     # than the sequences themselves
+    logging.warning(
+        "Recommend against using identifying keywords that are Sequences in pseudonymisation: %s",
+        value,
+    )
     return [pydicom.Dataset()]
 
 

--- a/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
+++ b/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
@@ -87,7 +87,7 @@ def _test_identifier_is_sequence_vr():
     logging.info("Using keyword with VR = UR")
 
     ds_input = pydicom.Dataset()
-
+    ds_input.PatientID = "ABC123"
     request_attributes_seq = dicom_dataset_from_dict(
         {
             "RequestAttributesSequence": [
@@ -122,7 +122,7 @@ def _test_identifier_is_sequence_vr():
         ds_anon.RequestAttributesSequence.RequestedProcedureID
         != "Tumour Identification"
     )
-    # and an element in the sequence that is not and identifier has been left as is
+    # and an element in the sequence that is not an identifier has been left as is
     assert (
         ds_anon.RequestAttributesSequence.ScheduledProcedureStepID
         == "Tumour ID with Dual Energy"

--- a/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
+++ b/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
@@ -127,7 +127,6 @@ def _test_identifier_is_sequence_vr():
         ds_anon.RequestAttributesSequence.ScheduledProcedureStepID
         == "Tumour ID with Dual Energy"
     )
-    return
 
 
 def _test_pseudonymise_file_at_path(

--- a/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
+++ b/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
@@ -19,7 +19,10 @@ from pymedphys._dicom.anonymise import (
 from pymedphys._dicom.constants.core import DICOM_SOP_CLASS_NAMES_MODE_PREFIXES
 from pymedphys._dicom.utilities import remove_file
 from pymedphys.experimental import pseudonymisation as pseudonymisation_api
-from pymedphys.tests.dicom.test_anonymise import get_test_filepaths
+from pymedphys.tests.dicom.test_anonymise import (
+    dicom_dataset_from_dict,
+    get_test_filepaths,
+)
 
 
 @pytest.mark.pydicom
@@ -71,6 +74,60 @@ def test_identifier_with_unknown_vr():
             replacement_strategy=replacement_strategy,
             identifying_keywords=identifying_keywords_with_vr_unknown_to_strategy,
         )
+
+
+@pytest.mark.pydicom
+def _test_identifier_is_sequence_vr():
+    replacement_strategy = pseudonymisation_api.pseudonymisation_dispatch
+    logging.info("Using pseudonymisation strategy")
+    identifying_keywords_no_SQ = ["PatientID", "RequestedProcedureID"]
+    identifying_keywords_with_SQ_vr = identifying_keywords_no_SQ.append(
+        "RequestAttributesSequence"
+    )
+    logging.info("Using keyword with VR = UR")
+
+    ds_input = pydicom.Dataset()
+
+    request_attributes_seq = dicom_dataset_from_dict(
+        {
+            "RequestAttributesSequence": [
+                {
+                    "RequestedProcedureID": "Tumour Identification",
+                    "ScheduledProcedureStepID": "Tumour ID with Dual Energy",
+                }
+            ]
+        }
+    )
+
+    ds_input.RequestAttributesSequence = request_attributes_seq
+    ds_anon = anonymise_dataset(
+        ds_input,
+        replacement_strategy=replacement_strategy,
+        identifying_keywords=identifying_keywords_with_SQ_vr,
+    )
+    # demonstrate that the entire sequence is emptied out
+    # even though that might make the data fail compliance (if the sequence has type 1
+    # or type 2)
+    assert "RequestedProcedureID" not in ds_anon.RequestAttributesSequence
+
+    ds_anon = anonymise_dataset(
+        ds_input,
+        replacement_strategy=replacement_strategy,
+        identifying_keywords=identifying_keywords_no_SQ,
+    )
+    # The sequence is not emptied out
+    assert "RequestedProcedureID" in ds_anon.RequestAttributesSequence
+    # but an element in the sequence that is an identifier has been pseudonymised
+    assert (
+        ds_anon.RequestAttributesSequence.RequestedProcedureID
+        != "Tumour Identification"
+    )
+    # and an element in the sequence that is not and identifier has been left as is
+    assert (
+        ds_anon.RequestAttributesSequence.ScheduledProcedureStepID
+        == "Tumour ID with Dual Energy"
+    )
+    return
 
 
 def _test_pseudonymise_file_at_path(


### PR DESCRIPTION
that were in the list of identifying keywords, e.g. RequestAttributesSequence
Remove keywords that are sequences from the default keyword list provided by pseudonymisation
 so that the contents get pseudonymised
Provide a dictionary entry in the strategy for SQ so that an empty sequence is provided
 if a programmer decides to put an identifier in that is a Sequence
Added error message to anonymise so that when there is a failure, the keyword and it's VR are identified, before raising the error again
TODO: provide a Validator so that keywords get validated against a strategy
Added a test that deals with both approaches
fixes issue #1034 