### PR TITLE
Add a function for confirming whether a strategy supports the VR for each of the keywords

### DIFF
--- a/docs/ref/lib/experimental/pseudonymisation.rst
+++ b/docs/ref/lib/experimental/pseudonymisation.rst
@@ -27,6 +27,7 @@ API
 ***
 
 .. autofunction:: pymedphys.experimental.pseudonymisation.get_default_pseudonymisation_keywords
+.. autofunction:: pymedphys.experimental.pseudonymisation.is_valid_strategy_for_keywords
 .. autoattribute:: pymedphys.experimental.pseudonymisation.pseudonymisation_dispatch
     :annotation: strategy, i.e. dictionary of VR and function references for anonymisation to achieve pseudonymisation
 

--- a/pymedphys/_experimental/pseudonymisation/__init__.py
+++ b/pymedphys/_experimental/pseudonymisation/__init__.py
@@ -20,10 +20,11 @@ from os.path import join as pjoin
 from pymedphys._dicom.anonymise import (
     anonymise_directory,
     anonymise_file,
+    get_baseline_keyword_vr_dict,
     get_default_identifying_keywords,
 )
 
-from . import strategy
+from . import strategy  # pylint: disable=import-self
 
 HERE = dirname(abspath(__file__))
 
@@ -115,3 +116,22 @@ def anonymise_with_pseudo_cli(args):
         raise FileNotFoundError(
             "No file or directory was found at the supplied input path."
         )
+
+
+def is_valid_strategy_for_keywords(
+    identifying_keywords=None, replacement_strategy=None
+):
+    test_keywords = identifying_keywords
+    if test_keywords is None:
+        test_keywords = get_default_pseudonymisation_keywords()
+    test_strategy = replacement_strategy
+    if test_strategy is None:
+        test_strategy = strategy.pseudonymisation_dispatch
+
+    baseline_keyword_vr_dict = get_baseline_keyword_vr_dict()
+    for keyword in test_keywords:
+        vr = baseline_keyword_vr_dict[keyword]
+        # pydicom.datadict.dictionary_VR(pydicom.datadict.tag_for_keyword(keyword))
+        if vr not in test_strategy:
+            return False
+    return True

--- a/pymedphys/_experimental/pseudonymisation/__init__.py
+++ b/pymedphys/_experimental/pseudonymisation/__init__.py
@@ -24,7 +24,7 @@ from pymedphys._dicom.anonymise import (
     get_default_identifying_keywords,
 )
 
-from . import strategy  # pylint: disable=import-self
+from . import strategy
 
 HERE = dirname(abspath(__file__))
 
@@ -121,17 +121,16 @@ def anonymise_with_pseudo_cli(args):
 def is_valid_strategy_for_keywords(
     identifying_keywords=None, replacement_strategy=None
 ):
-    test_keywords = identifying_keywords
-    if test_keywords is None:
-        test_keywords = get_default_pseudonymisation_keywords()
-    test_strategy = replacement_strategy
-    if test_strategy is None:
-        test_strategy = strategy.pseudonymisation_dispatch
+    if identifying_keywords is None:
+        identifying_keywords = get_default_pseudonymisation_keywords()
+
+    if replacement_strategy is None:
+        replacement_strategy = strategy.pseudonymisation_dispatch
 
     baseline_keyword_vr_dict = get_baseline_keyword_vr_dict()
-    for keyword in test_keywords:
+    for keyword in identifying_keywords:
         vr = baseline_keyword_vr_dict[keyword]
         # pydicom.datadict.dictionary_VR(pydicom.datadict.tag_for_keyword(keyword))
-        if vr not in test_strategy:
+        if vr not in replacement_strategy:
             return False
     return True

--- a/pymedphys/experimental/pseudonymisation.py
+++ b/pymedphys/experimental/pseudonymisation.py
@@ -3,5 +3,6 @@
 
 from pymedphys._experimental.pseudonymisation import (
     get_default_pseudonymisation_keywords,
+    is_valid_strategy_for_keywords,
 )
 from pymedphys._experimental.pseudonymisation.strategy import pseudonymisation_dispatch

--- a/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
+++ b/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
@@ -93,13 +93,15 @@ def test_identifier_is_sequence_vr():
         "RequestAttributesSequence",
     ]
 
+    identifying_requested_procedure_id = "Tumour Identification"
+    non_identifying_scheduled_procedure_step_id = "Tumour ID with Dual Energy"
     ds_input = dicom_dataset_from_dict(
         {
             "PatientID": "ABC123",
             "RequestAttributesSequence": [
                 {
-                    "RequestedProcedureID": "Tumour Identification",
-                    "ScheduledProcedureStepID": "Tumour ID with Dual Energy",
+                    "RequestedProcedureID": identifying_requested_procedure_id,
+                    "ScheduledProcedureStepID": non_identifying_scheduled_procedure_step_id,
                 }
             ],
         }
@@ -132,12 +134,12 @@ def test_identifier_is_sequence_vr():
     # but an element in the sequence that is an identifier has been pseudonymised
     assert (
         ds_anon.RequestAttributesSequence[0].RequestedProcedureID
-        != "Tumour Identification"
+        != identifying_requested_procedure_id
     )
     # and an element in the sequence that is not an identifier has been left as is
     assert (
         ds_anon.RequestAttributesSequence[0].ScheduledProcedureStepID
-        == "Tumour ID with Dual Energy"
+        == non_identifying_scheduled_procedure_step_id
     )
 
 


### PR DESCRIPTION
fix broken test that was prefixed with an underscore and had mangled  construction of RequestAttributesSequence
include testing that the pseudonymisation does not support VR of UR regardless of what might be in the data by
using the is_valid_strategy_for_keywords function