### PR TITLE
changed strategies from dict to immutables.Map

### DIFF
--- a/pymedphys/_dicom/anonymise/strategy.py
+++ b/pymedphys/_dicom/anonymise/strategy.py
@@ -15,7 +15,7 @@
 import functools
 import logging
 
-from pymedphys._imports import pydicom
+from pymedphys._imports import immutables, pydicom
 
 from pymedphys._dicom.constants import PYMEDPHYS_ROOT_UID
 
@@ -60,9 +60,16 @@ def _get_vr_anonymous_hardcode_replacement_value(current_value, value_representa
 _keys = list(VR_TO_REPLACEMENT_MAP.keys())
 _keys.append("SQ")
 
-ANONYMISATION_HARDCODE_DISPATCH = {
+_ANONYMISATION_HARDCODE_DISPATCH = {
     key: functools.partial(
         _get_vr_anonymous_hardcode_replacement_value, value_representation=key
     )
     for key in _keys
 }
+
+
+def _wrap_hardcode_dispatch():
+    return immutables.Map(_ANONYMISATION_HARDCODE_DISPATCH)
+
+
+ANONYMISATION_HARDCODE_DISPATCH = _wrap_hardcode_dispatch()

--- a/pymedphys/_experimental/pseudonymisation/strategy.py
+++ b/pymedphys/_experimental/pseudonymisation/strategy.py
@@ -19,7 +19,7 @@ import logging
 import random
 from decimal import Decimal, DecimalTuple
 
-from pymedphys._imports import pydicom
+from pymedphys._imports import immutables, pydicom
 
 from pymedphys._dicom.anonymise import get_baseline_keyword_vr_dict
 from pymedphys._dicom.constants import PYMEDPHYS_ROOT_UID
@@ -366,7 +366,7 @@ def _pseudonymise_US(value):
     return _pseudonymise_unchanged(value)
 
 
-pseudonymisation_dispatch = dict(
+_pseudonymisation_dispatch = dict(
     {
         "AE": _pseudonymise_AE,
         "AS": _pseudonymise_AS,
@@ -388,3 +388,10 @@ pseudonymisation_dispatch = dict(
         "US": _pseudonymise_US,
     }
 )
+
+
+def _wrap_pseudonymisation_dispatch():
+    return immutables.Map(_pseudonymisation_dispatch)
+
+
+pseudonymisation_dispatch = _wrap_pseudonymisation_dispatch()


### PR DESCRIPTION
made the dict private
created a private function to wrap the conversion to immutables.Map so that the additional key/value pairs used to store other control parameters/values can be addressed in the wrapping function.