### PR TITLE
change behaviour in anonymise_directory in a backward compatible fashion

### DIFF
--- a/pymedphys/_dicom/anonymise/api.py
+++ b/pymedphys/_dicom/anonymise/api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import logging
 import os
 import pprint
 from copy import deepcopy
@@ -223,6 +224,11 @@ def anonymise_file(
 
     identifying_keywords: ``list``, optional
         If left as None, the default values for/list of identifying keywords are used
+
+    Returns
+    -------
+    ``str``
+    The file path of the anonymised file
     """
     dicom_filepath = str(dicom_filepath)
 
@@ -334,12 +340,18 @@ def anonymise_directory(
 
     identifying_keywords: ``list``, optional
         If left as None, the default values for/list of identifying keywords are used
+
+    Returns
+    -------
+    ``list`` of anonymised file paths
     """
     dicom_dirpath = str(dicom_dirpath)
 
     dicom_filepaths = glob(dicom_dirpath + "/**/*.dcm", recursive=True)
     failing_filepaths = []
-    # errors = []
+    successful_filepaths = []
+    anon_filepaths = []
+    errors = []
 
     for dicom_filepath in dicom_filepaths:
         if output_dirpath is not None:
@@ -347,19 +359,26 @@ def anonymise_directory(
             output_filepath = os.path.join(output_dirpath, relative_path)
         else:
             output_filepath = None
-
-        anonymise_file(
-            dicom_filepath,
-            output_filepath=output_filepath,
-            delete_original_file=delete_original_files,
-            anonymise_filename=anonymise_filenames,
-            replace_values=replace_values,
-            keywords_to_leave_unchanged=keywords_to_leave_unchanged,
-            delete_private_tags=delete_private_tags,
-            delete_unknown_tags=delete_unknown_tags,
-            replacement_strategy=replacement_strategy,
-            identifying_keywords=identifying_keywords,
-        )
+        try:
+            dicom_anon_filepath = anonymise_file(
+                dicom_filepath,
+                output_filepath=output_filepath,
+                delete_original_file=delete_original_files,
+                anonymise_filename=anonymise_filenames,
+                replace_values=replace_values,
+                keywords_to_leave_unchanged=keywords_to_leave_unchanged,
+                delete_private_tags=delete_private_tags,
+                delete_unknown_tags=delete_unknown_tags,
+                replacement_strategy=replacement_strategy,
+                identifying_keywords=identifying_keywords,
+            )
+            successful_filepaths.append(dicom_filepath)
+            anon_filepaths.append(dicom_anon_filepath)
+        except BaseException as error:
+            errors.append(error)
+            failing_filepaths.append(dicom_filepath)
+            logging.warning("Unable to anonymise %s", dicom_filepath)
+            logging.warning(str(error))
 
     # Separate loop provides the ability to raise Exceptions from the
     # unsuccessful deletion of the original DICOM files while preventing
@@ -368,6 +387,11 @@ def anonymise_directory(
         for dicom_filepath in dicom_filepaths:
             if not dicom_filepath in failing_filepaths:
                 remove_file(dicom_filepath)
+
+    if len(errors) > 0:
+        logging.info("Succeeded in anonymising: \n%s", "\n".join(successful_filepaths))
+        raise errors[0]
+    return anon_filepaths
 
 
 def anonymise_cli(args):

--- a/pymedphys/_dicom/anonymise/api.py
+++ b/pymedphys/_dicom/anonymise/api.py
@@ -280,6 +280,7 @@ def anonymise_directory(
     delete_unknown_tags=None,
     replacement_strategy=None,
     identifying_keywords=None,
+    fail_fast=True,
 ):
     r"""A simple tool to anonymise all DICOM files in a directory and
     its subdirectories.
@@ -341,6 +342,11 @@ def anonymise_directory(
     identifying_keywords: ``list``, optional
         If left as None, the default values for/list of identifying keywords are used
 
+    fail_fast: ``bool``, optional, default to True
+        If set to false, will continue attempts to convert files and only
+        after completing translation and deleting original files (if specified)
+        will raise an error to indicate not all files could be translated.
+
     Returns
     -------
     ``list`` of anonymised file paths
@@ -379,6 +385,8 @@ def anonymise_directory(
             failing_filepaths.append(dicom_filepath)
             logging.warning("Unable to anonymise %s", dicom_filepath)
             logging.warning(str(error))
+            if fail_fast:
+                raise error
 
     # Separate loop provides the ability to raise Exceptions from the
     # unsuccessful deletion of the original DICOM files while preventing

--- a/pymedphys/_dicom/anonymise/api.py
+++ b/pymedphys/_dicom/anonymise/api.py
@@ -374,7 +374,7 @@ def anonymise_directory(
             )
             successful_filepaths.append(dicom_filepath)
             anon_filepaths.append(dicom_anon_filepath)
-        except BaseException as error:
+        except (AttributeError, LookupError, TypeError, OSError, ValueError) as error:
             errors.append(error)
             failing_filepaths.append(dicom_filepath)
             logging.warning("Unable to anonymise %s", dicom_filepath)

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -381,7 +381,7 @@ def test_anonymise_directory(tmp_path):
         assert not is_anonymised_directory(tmp_path)
 
         # Test file deletion
-        anonymise_directory(
+        anon_path_list = anonymise_directory(
             tmp_path, delete_original_files=False, anonymise_filenames=False
         )
         # # File should be anonymised but not dir, since original file
@@ -389,9 +389,11 @@ def test_anonymise_directory(tmp_path):
         assert is_anonymised_file(temp_anon_filepath)
         assert exists(temp_filepath)
         assert not is_anonymised_directory(tmp_path)
+        assert anon_path_list is not None
+        assert anon_path_list[0] == temp_anon_filepath
 
         remove_file(temp_anon_filepath)
-        anonymise_directory(
+        anon_path_list = anonymise_directory(
             tmp_path, delete_original_files=True, anonymise_filenames=False
         )
         # # File and dir should be anonymised since original file should
@@ -399,6 +401,7 @@ def test_anonymise_directory(tmp_path):
         assert is_anonymised_file(temp_anon_filepath)
         assert not exists(temp_filepath)
         assert is_anonymised_directory(tmp_path)
+        assert anon_path_list[0] == temp_anon_filepath
 
     finally:
         remove_file(temp_anon_filepath)

--- a/pymedphys/tests/dicom/test_anonymise.py
+++ b/pymedphys/tests/dicom/test_anonymise.py
@@ -376,6 +376,10 @@ def _test_anonymise_file_at_path(test_file_path):
 def test_anonymise_directory(tmp_path):
     temp_filepath = tmp_path / "test.dcm"
     temp_anon_filepath = label_dicom_filepath_as_anonymised(temp_filepath)
+
+    temp_record_filepath = tmp_path / "test_record.dcm"
+    temp_anon_record_filepath = label_dicom_filepath_as_anonymised(temp_record_filepath)
+
     try:
         copyfile(get_rtplan_test_file_path(), temp_filepath)
         assert not is_anonymised_directory(tmp_path)
@@ -403,8 +407,43 @@ def test_anonymise_directory(tmp_path):
         assert is_anonymised_directory(tmp_path)
         assert anon_path_list[0] == temp_anon_filepath
 
+        # Test fail fast vs. fail at last
+        # if the function fails fast, the specified removal
+        # will not take place
+        # if the function does not fail fail, the specified
+        # removal will take place
+        logging.warning("Testing fail fast")
+        remove_file(temp_anon_filepath)
+        copyfile(get_rtplan_test_file_path(), temp_filepath)
+        copyfile(get_treatment_record_test_file_path(), temp_record_filepath)
+        ds_record = pydicom.dcmread(temp_record_filepath, force=True)
+        # deliberately add a DICOM element that is not in the current
+        # dictionary
+        ds_record.add_new([0x300A, 0x9999], "FL", [1.0, 1.0])
+        pydicom.dcmwrite(temp_record_filepath, ds_record)
+        with pytest.raises((KeyError, ValueError)):
+            anon_path_list = anonymise_directory(
+                tmp_path,
+                delete_original_files=True,
+                anonymise_filenames=False,
+                fail_fast=True,
+            )
+            logging.warning(anon_path_list)
+            assert exists(temp_filepath)
+
+        with pytest.raises((KeyError, ValueError)):
+            anon_path_list = anonymise_directory(
+                tmp_path,
+                delete_original_files=True,
+                anonymise_filenames=False,
+                fail_fast=False,
+            )
+            logging.warning(anon_path_list)
+            assert not exists(temp_filepath)
+
     finally:
         remove_file(temp_anon_filepath)
+        remove_file(temp_anon_record_filepath)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
  accumulate list of anonymised files / paths
  catch errors in file anonymisation and log which files failed to anonymise
  if any errors took place, after all cleanup, raise the first error
  if no errors took place, return the list of anonymised files / paths

also... updated docstring for anonymise_file and anonymise_directory to include return type and description

This provides for a reasonably consistent set of return values across the three main anonymise_xxx()
which I will make use of in the proposed facade methods