### PR TITLE
Support dutch timestamp within headers

### DIFF
--- a/pymedphys/_data/hashes.json
+++ b/pymedphys/_data/hashes.json
@@ -84,7 +84,7 @@
   "tomo_mapcheck_test.txt": "93375b1b1a3eeee5f4810762545f42055f6b3b37",
   "tps_compare_dicom_files.zip": "d0d0a9676ae8ff8fca080611944fdafab5b6e83d",
   "treatment-record-anonymisation.zip": "274f3e84af33887645a12f4256b96d35f1380909",
-  "trf-references-and-baselines.zip": "a2d5bf8bcbd5d5617e9c6f476d3bff450d7779c9",
+  "trf-references-and-baselines.zip": "a64f37c2a07d561d5bc4d431377261016287f32a",
   "washed_out_bb.png": "06c7c32a1a4be6d2ebade915f28a998e3039c3a4",
   "water_phantom.zip": "b93ea8d89cf4030524ace0e67fa08082efd88776",
   "wlutz_arc_session.zip": "5db4f8becdaed134010b83a03fbd3a638745521c",

--- a/pymedphys/_data/urls.json
+++ b/pymedphys/_data/urls.json
@@ -30,6 +30,6 @@
   "rtplan-anonymisation.zip": "https://zenodo.org/record/3930533/files/rtplan-anonymisation.zip?download=1",
   "treatment-record-anonymisation.zip": "https://zenodo.org/record/3931186/files/treatmentrecord-anonymisation.zip?download=1",
   "negative-mu-density.trf": "https://zenodo.org/record/3973722/files/negative_mu_density.trf?download=1",
-  "trf-references-and-baselines.zip": "https://zenodo.org/record/3987725/files/trf-references-and-baselines.zip?download=1",
+  "trf-references-and-baselines.zip": "https://zenodo.org/record/4087961/files/trf-references-and-baselines.zip?download=1",
   "dicom-to-delivery-issue-#1047.zip": "https://github.com/pymedphys/pymedphys/files/5212087/NPCA_Anonymised.zip"
 }

--- a/pymedphys/_trf/decode/header.py
+++ b/pymedphys/_trf/decode/header.py
@@ -33,7 +33,7 @@ def determine_header_length(trf_contents):
 def decode_header(trf_header_contents):
     match = re.match(
         br"[\x00-\x19]"  # start bit
-        br"(\d\d/\d\d/\d\d \d\d:\d\d:\d\d Z)"  # date
+        br"(\d\d[/-]\d\d[/-]\d\d \d\d:\d\d:\d\d Z)"  # date
         br"[\x00-\x19]"  # divider bit
         br"((\+|\-)\d\d:\d\d)"  # time zone
         br"[\x00-\x25]"  # divider bit

--- a/pymedphys/_version.py
+++ b/pymedphys/_version.py
@@ -1,4 +1,4 @@
 # pylint: disable=invalid-name, missing-docstring
 
-version_info = [0, 33, 0, "dev2"]
-__version__ = "0.33.0dev2"
+version_info = [0, 34, 0, "dev2"]
+__version__ = "0.34.0dev2"

--- a/pymedphys/_version.py
+++ b/pymedphys/_version.py
@@ -1,4 +1,4 @@
 # pylint: disable=invalid-name, missing-docstring
 
-version_info = [0, 33, 0]
-__version__ = "0.33.0"
+version_info = [0, 33, 0, "dev2"]
+__version__ = "0.33.0dev2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymedphys"
-version = "0.33.0"
+version = "0.33.0dev2"
 readme = "README.rst"
 description = "Medical Physics library"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymedphys"
-version = "0.33.0dev2"
+version = "0.34.0dev2"
 readme = "README.rst"
 description = "Medical Physics library"
 authors = [


### PR DESCRIPTION
See https://github.com/pymedphys/pymedphys/pull/1093 for the base PR.

The new testing file can be seen over at https://zenodo.org/record/4087961. The new files added are highlighted below:

![image](https://user-images.githubusercontent.com/6559099/95969436-73592680-0e5a-11eb-87b0-c62fdbc77665.png)

I ran `pymedphys trf to-csv` on that file without this fix and it failed to decode with an error message of "unexpected header format". After this, it worked as intended. No other baseline or reference decoding results within the testing suite were altered with this change.

See the error message from pytest when this new TRF file is included but this change is not made:

```bash
simon@dads-desktop:~/git/pymedphys$ poetry run pytest pymedphys/tests/trf --run-only-slow
Test session starts (platform: linux, Python 3.7.8, pytest 6.1.0, pytest-sugar 0.9.4)
rootdir: /home/simon/git/pymedphys
plugins: hypothesis-5.36.1, pylint-0.17.0, sugar-0.9.4
collecting ... 2020-10-14 20:25:16.469664: I tensorflow/stream_executor/platform/default/dso_loader.cc:48] Successfully opened dynamic library libcudart.so.10.1


――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_conversions ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    @pytest.mark.slow
    def test_conversions():
        data_paths = pymedphys.zip_data_paths("trf-references-and-baselines.zip")
    
        files_with_references = [
            path
            for path in data_paths
            if path.parent.name == "with_reference" and path.suffix == ".trf"
        ]
    
        assert len(files_with_references) >= 5
    
        files_without_references = [
            path
            for path in data_paths
            if path.parent.name == "with_baseline" and path.suffix == ".trf"
        ]
    
        assert len(files_without_references) >= 4
    
        with tempfile.TemporaryDirectory() as output_directory:
            for filepath in files_with_references:
                convert_and_check_against_reference(filepath, output_directory)
    
            for filepath in files_without_references:
>               convert_and_check_against_baseline(filepath, output_directory)

pymedphys/tests/trf/test_decode.py:99: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pymedphys/tests/trf/test_decode.py:56: in convert_and_check_against_baseline
    convert_and_check(filepath, output_directory, baseline_dataframe)
pymedphys/tests/trf/test_decode.py:68: in convert_and_check
    _, table_filepath = trf2csv(filepath, output_directory=output_directory)
pymedphys/_trf/decode/trf2csv.py:64: in trf2csv
    dataframes["header"], dataframes["table"] = trf2pandas(trf_filepath)
pymedphys/_trf/decode/trf2pandas.py:32: in trf2pandas
    header_dataframe = header_as_dataframe(trf_header_contents)
pymedphys/_trf/decode/trf2pandas.py:43: in header_as_dataframe
    header = decode_header(trf_header_contents)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

trf_header_contents = b'\x1320-09-24 06:29:58 Z\x06+02:00\x0b6_320/6_320\x042325\x00\x00\x00\x00\x00\xb3\xc0@\x03\x00\x00\x00^\x01\x00\x00\x...dc\x00\xe4\t\xdc\x00\xe5\t\xdc\x00\xe6\t\xdc\x00\xe7\t\xdc\x00\xe8\t\xdc\x00\xe9\t\xdc\x00\xea\t\xdc\x00\xeb\t\xdc\x00'

    def decode_header(trf_header_contents):
        match = re.match(
            br"[\x00-\x19]"  # start bit
            br"(\d\d/\d\d/\d\d \d\d:\d\d:\d\d Z)"  # date
            br"[\x00-\x19]"  # divider bit
            br"((\+|\-)\d\d:\d\d)"  # time zone
            br"[\x00-\x25]"  # divider bit
            br"([\x20-\xFF]*)"  # field label and name
            br"[\x00-\x19]"  # divider bit
            br"([\x20-\xFF]+)"  # machine name
            br"[\x00-\x19]",  # divider bit
            trf_header_contents,
        )
    
        if match is None:
            print(trf_header_contents)
>           raise ValueError("Logfile header not of an expected form.")
E           ValueError: Logfile header not of an expected form.

pymedphys/_trf/decode/header.py:49: ValueError
------------------------------------------------------------- Captured stdout call --------------------------------------------------------------
b'\x1320-09-24 06:29:58 Z\x06+02:00\x0b6_320/6_320\x042325\x00\x00\x00\x00\x00\xb3\xc0@\x03\x00\x00\x00^\x01\x00\x00\xc0\x08o\x00\x81\x08d\x00\xef\to\x00\xee\to\x00\xbe\x08o\x00r\x08e\x00\x98\x08o\x00\xed\to\x00\xb0\x08\x81\x00\xb0\x08\xdc\x00\xb1\x08\x81\x00\xb1\x08\xdc\x00\xb2\x08\x81\x00\xb2\x08\xdc\x00\xb3\x08\x81\x00\xb3\x08\xdc\x00\xb4\x08\x81\x00\xb4\x08\xdc\x00\xb5\x08\x81\x00\xb5\x08\xdc\x00\x0c\x08\x81\x00\r\x08\x81\x00\x0c\x08\xdc\x00\r\x08\xdc\x00\x10\x08\x81\x00\x11\x08\x81\x00\x10\x08\xdc\x00\x11\x08\xdc\x00t\t\xe3\x00\xc4\t\xe3\x00L\t\x81\x00M\t\x81\x00N\t\x81\x00O\t\x81\x00P\t\x81\x00Q\t\x81\x00R\t\x81\x00S\t\x81\x00T\t\x81\x00U\t\x81\x00V\t\x81\x00W\t\x81\x00X\t\x81\x00Y\t\x81\x00Z\t\x81\x00[\t\x81\x00\\\t\x81\x00]\t\x81\x00^\t\x81\x00_\t\x81\x00`\t\x81\x00a\t\x81\x00b\t\x81\x00c\t\x81\x00d\t\x81\x00e\t\x81\x00f\t\x81\x00g\t\x81\x00h\t\x81\x00i\t\x81\x00j\t\x81\x00k\t\x81\x00l\t\x81\x00m\t\x81\x00n\t\x81\x00o\t\x81\x00p\t\x81\x00q\t\x81\x00r\t\x81\x00s\t\x81\x00t\t\x81\x00u\t\x81\x00v\t\x81\x00w\t\x81\x00x\t\x81\x00y\t\x81\x00z\t\x81\x00{\t\x81\x00|\t\x81\x00}\t\x81\x00~\t\x81\x00\x7f\t\x81\x00\x80\t\x81\x00\x81\t\x81\x00\x82\t\x81\x00\x83\t\x81\x00\x84\t\x81\x00\x85\t\x81\x00\x86\t\x81\x00\x87\t\x81\x00\x88\t\x81\x00\x89\t\x81\x00\x8a\t\x81\x00\x8b\t\x81\x00\x8c\t\x81\x00\x8d\t\x81\x00\x8e\t\x81\x00\x8f\t\x81\x00\x90\t\x81\x00\x91\t\x81\x00\x92\t\x81\x00\x93\t\x81\x00\x94\t\x81\x00\x95\t\x81\x00\x96\t\x81\x00\x97\t\x81\x00\x98\t\x81\x00\x99\t\x81\x00\x9a\t\x81\x00\x9b\t\x81\x00\x9c\t\x81\x00\x9d\t\x81\x00\x9e\t\x81\x00\x9f\t\x81\x00\xa0\t\x81\x00\xa1\t\x81\x00\xa2\t\x81\x00\xa3\t\x81\x00\xa4\t\x81\x00\xa5\t\x81\x00\xa6\t\x81\x00\xa7\t\x81\x00\xa8\t\x81\x00\xa9\t\x81\x00\xaa\t\x81\x00\xab\t\x81\x00\xac\t\x81\x00\xad\t\x81\x00\xae\t\x81\x00\xaf\t\x81\x00\xb0\t\x81\x00\xb1\t\x81\x00\xb2\t\x81\x00\xb3\t\x81\x00\xb4\t\x81\x00\xb5\t\x81\x00\xb6\t\x81\x00\xb7\t\x81\x00\xb8\t\x81\x00\xb9\t\x81\x00\xba\t\x81\x00\xbb\t\x81\x00\xbc\t\x81\x00\xbd\t\x81\x00\xbe\t\x81\x00\xbf\t\x81\x00\xc0\t\x81\x00\xc1\t\x81\x00\xc2\t\x81\x00\xc3\t\x81\x00\xc4\t\x81\x00\xc5\t\x81\x00\xc6\t\x81\x00\xc7\t\x81\x00\xc8\t\x81\x00\xc9\t\x81\x00\xca\t\x81\x00\xcb\t\x81\x00\xcc\t\x81\x00\xcd\t\x81\x00\xce\t\x81\x00\xcf\t\x81\x00\xd0\t\x81\x00\xd1\t\x81\x00\xd2\t\x81\x00\xd3\t\x81\x00\xd4\t\x81\x00\xd5\t\x81\x00\xd6\t\x81\x00\xd7\t\x81\x00\xd8\t\x81\x00\xd9\t\x81\x00\xda\t\x81\x00\xdb\t\x81\x00\xdc\t\x81\x00\xdd\t\x81\x00\xde\t\x81\x00\xdf\t\x81\x00\xe0\t\x81\x00\xe1\t\x81\x00\xe2\t\x81\x00\xe3\t\x81\x00\xe4\t\x81\x00\xe5\t\x81\x00\xe6\t\x81\x00\xe7\t\x81\x00\xe8\t\x81\x00\xe9\t\x81\x00\xea\t\x81\x00\xeb\t\x81\x00L\t\xdc\x00M\t\xdc\x00N\t\xdc\x00O\t\xdc\x00P\t\xdc\x00Q\t\xdc\x00R\t\xdc\x00S\t\xdc\x00T\t\xdc\x00U\t\xdc\x00V\t\xdc\x00W\t\xdc\x00X\t\xdc\x00Y\t\xdc\x00Z\t\xdc\x00[\t\xdc\x00\\\t\xdc\x00]\t\xdc\x00^\t\xdc\x00_\t\xdc\x00`\t\xdc\x00a\t\xdc\x00b\t\xdc\x00c\t\xdc\x00d\t\xdc\x00e\t\xdc\x00f\t\xdc\x00g\t\xdc\x00h\t\xdc\x00i\t\xdc\x00j\t\xdc\x00k\t\xdc\x00l\t\xdc\x00m\t\xdc\x00n\t\xdc\x00o\t\xdc\x00p\t\xdc\x00q\t\xdc\x00r\t\xdc\x00s\t\xdc\x00t\t\xdc\x00u\t\xdc\x00v\t\xdc\x00w\t\xdc\x00x\t\xdc\x00y\t\xdc\x00z\t\xdc\x00{\t\xdc\x00|\t\xdc\x00}\t\xdc\x00~\t\xdc\x00\x7f\t\xdc\x00\x80\t\xdc\x00\x81\t\xdc\x00\x82\t\xdc\x00\x83\t\xdc\x00\x84\t\xdc\x00\x85\t\xdc\x00\x86\t\xdc\x00\x87\t\xdc\x00\x88\t\xdc\x00\x89\t\xdc\x00\x8a\t\xdc\x00\x8b\t\xdc\x00\x8c\t\xdc\x00\x8d\t\xdc\x00\x8e\t\xdc\x00\x8f\t\xdc\x00\x90\t\xdc\x00\x91\t\xdc\x00\x92\t\xdc\x00\x93\t\xdc\x00\x94\t\xdc\x00\x95\t\xdc\x00\x96\t\xdc\x00\x97\t\xdc\x00\x98\t\xdc\x00\x99\t\xdc\x00\x9a\t\xdc\x00\x9b\t\xdc\x00\x9c\t\xdc\x00\x9d\t\xdc\x00\x9e\t\xdc\x00\x9f\t\xdc\x00\xa0\t\xdc\x00\xa1\t\xdc\x00\xa2\t\xdc\x00\xa3\t\xdc\x00\xa4\t\xdc\x00\xa5\t\xdc\x00\xa6\t\xdc\x00\xa7\t\xdc\x00\xa8\t\xdc\x00\xa9\t\xdc\x00\xaa\t\xdc\x00\xab\t\xdc\x00\xac\t\xdc\x00\xad\t\xdc\x00\xae\t\xdc\x00\xaf\t\xdc\x00\xb0\t\xdc\x00\xb1\t\xdc\x00\xb2\t\xdc\x00\xb3\t\xdc\x00\xb4\t\xdc\x00\xb5\t\xdc\x00\xb6\t\xdc\x00\xb7\t\xdc\x00\xb8\t\xdc\x00\xb9\t\xdc\x00\xba\t\xdc\x00\xbb\t\xdc\x00\xbc\t\xdc\x00\xbd\t\xdc\x00\xbe\t\xdc\x00\xbf\t\xdc\x00\xc0\t\xdc\x00\xc1\t\xdc\x00\xc2\t\xdc\x00\xc3\t\xdc\x00\xc4\t\xdc\x00\xc5\t\xdc\x00\xc6\t\xdc\x00\xc7\t\xdc\x00\xc8\t\xdc\x00\xc9\t\xdc\x00\xca\t\xdc\x00\xcb\t\xdc\x00\xcc\t\xdc\x00\xcd\t\xdc\x00\xce\t\xdc\x00\xcf\t\xdc\x00\xd0\t\xdc\x00\xd1\t\xdc\x00\xd2\t\xdc\x00\xd3\t\xdc\x00\xd4\t\xdc\x00\xd5\t\xdc\x00\xd6\t\xdc\x00\xd7\t\xdc\x00\xd8\t\xdc\x00\xd9\t\xdc\x00\xda\t\xdc\x00\xdb\t\xdc\x00\xdc\t\xdc\x00\xdd\t\xdc\x00\xde\t\xdc\x00\xdf\t\xdc\x00\xe0\t\xdc\x00\xe1\t\xdc\x00\xe2\t\xdc\x00\xe3\t\xdc\x00\xe4\t\xdc\x00\xe5\t\xdc\x00\xe6\t\xdc\x00\xe7\t\xdc\x00\xe8\t\xdc\x00\xe9\t\xdc\x00\xea\t\xdc\x00\xeb\t\xdc\x00'

 pymedphys/tests/trf/test_decode.py ⨯                                                                                             100% ██████████
=============================================================== warnings summary ================================================================
pymedphys/tests/trf/test_decode.py::test_conversions
pymedphys/tests/trf/test_decode.py::test_conversions
  /home/simon/.pyenv/versions/3.7.8/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================ short test summary info ============================================================
FAILED pymedphys/tests/trf/test_decode.py::test_conversions - ValueError: Logfile header not of an expected form.

Results (19.19s):
       1 failed
         - pymedphys/tests/trf/test_decode.py:74 test_conversions
```