### PR TITLE
Spin slow tests out into their own vm

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -81,7 +81,7 @@ jobs:
 
         include:
           - os: 'ubuntu'
-            python-version: 3.9
+            python-version: 3.8
           - os: 'windows'
             python-version: 3.7
           - os: 'macos'

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu', 'macos', 'windows']
-        task: ['tests', 'docs', 'stackoverflow', 'updates', 'cypress']
+        task: ['tests', 'docs', 'stackoverflow', 'updates', 'cypress', 'slow']
         exclude:
           - os: 'windows'
             task: 'stackoverflow'
@@ -67,6 +67,8 @@ jobs:
             task: 'updates'
           - os: 'windows'
             task: 'cypress'
+          - os: 'windows'
+            task: 'slow'
 
           - os: 'macos'
             task: 'stackoverflow'
@@ -74,10 +76,12 @@ jobs:
             task: 'updates'
           - os: 'macos'
             task: 'cypress'
+          - os: 'macos'
+            task: 'slow'
 
         include:
           - os: 'ubuntu'
-            python-version: 3.8
+            python-version: 3.9
           - os: 'windows'
             python-version: 3.7
           - os: 'macos'
@@ -225,7 +229,7 @@ jobs:
 ## Install with Tests Environment
 
     - name: Install a tests environment
-      if: matrix.task == 'tests' || matrix.task == 'cypress'
+      if: matrix.task == 'tests' || matrix.task == 'cypress' || matrix.task == 'slow'
       run: |
         poetry install -E user -E tests
 
@@ -286,7 +290,7 @@ jobs:
 ## Slow
 
     - name: Run slow tests
-      if: matrix.os == 'ubuntu' && matrix.task == 'tests'
+      if: matrix.task == 'slow'
       run: |
         poetry run pymedphys dev tests -v --run-only-slow
 


### PR DESCRIPTION
We now have access to 20 concurrent runs. The "slow" tests seem to be a limiting factor within the ubuntu workflows. Will just spin those out into their own VM.

Ubuntu tests, given it is the fastest OS/VM, is still doing the extra work of pylint and doctests.

Main goal is to make each run take no longer than Windows takes to do the bare minimum tests (~8 minutes):

![image](https://user-images.githubusercontent.com/6559099/98036063-7c438380-1e6d-11eb-979d-9f32f3d0cf57.png)
