### PR TITLE
Add redirect for app.pymedphys.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -41,7 +41,7 @@
 [[redirects]]
   from = "https://app.pymedphys.com/*"
   to = "https://share.streamlit.io/pymedphys/pymedphys/main/app.py/:splat"
-  status = 301
+  status = 302
   force = true
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,12 @@
   force = true
 
 [[redirects]]
+  from = "https://app.pymedphys.com/*"
+  to = "https://share.streamlit.io/pymedphys/pymedphys/main/app.py/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "https://pymedphys.netlify.com/*"
   to = "https://docs.pymedphys.com/:splat"
   status = 301


### PR DESCRIPTION
Make it so that the website URL we share far and wide is https://app.pymedphys.com and then, if we ever change how we are hosting the online app, we can just change where this URL redirects to.