### PR TITLE
Remove special MacOS install instructions

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -200,11 +200,6 @@ jobs:
 
 # System installs
 
-    - name: Install FreeTDS on MacOS
-      if: matrix.os == 'macos'
-      run: |
-        brew install freetds
-
     - name: Install Pandoc on Ubuntu
       if: ( matrix.task == 'docs' || matrix.task == 'updates' ) && matrix.os == 'ubuntu'
       run: |

--- a/lib/pymedphys/docs/howto/get-started.rst
+++ b/lib/pymedphys/docs/howto/get-started.rst
@@ -12,8 +12,8 @@ Install Python
 
 In order to make use of the PyMedPhys library, you'll need Python installed on
 your workstation. On Windows we recommend that you install the
-Anaconda Python distribution. Download the latest Anaconda **Python 3** (not 2)
-version from `here <https://www.anaconda.com/download/>`__.
+Anaconda Python distribution. Download the latest Anaconda
+version from `here <https://www.anaconda.com/products/individual#Downloads>`__.
 
 .. note::
 
@@ -44,8 +44,8 @@ Python. The ``[user]`` option is needed to install pymedphys with its
 dependencies which you may need during your use of pymedphys.
 
 
-A minimal installation
-----------------------
+A minimal installation (Advanced users only)
+--------------------------------------------
 
 If you're not interested in installing PyMedPhys' dependencies you can choose
 to skip the ``[user]`` option as so:
@@ -55,40 +55,8 @@ to skip the ``[user]`` option as so:
     pip install pymedphys
 
 
-Installation on MacOS
----------------------
-
-One of PyMedPhys' dependencies is ``pymssql``. Before installing PyMedPhys on
-MacOS you need first install both ``freetds`` via ``homebrew`` and ``Cython``.
-To do this follow the steps below:
-
-To install homebrew (as described at <https://brew.sh/>):
-
-.. code:: bash
-
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-Then to install ``freetds`` open a new shell, then run:
-
-.. code:: bash
-
-    brew install freetds
-
-And lastly to install cython run:
-
-.. code:: bash
-
-    pip install cython
-
-Then you will be able to successfully run:
-
-.. code:: bash
-
-    pip install pymedphys[user]
-
-
-Installing the Bleeding Edge version of PyMedPhys
-=================================================
+Installing the Bleeding Edge version of PyMedPhys (Advanced users only)
+=======================================================================
 
 If you wish to be able to contribute to PyMedPhys itself you are going to want
 to instead install PyMedPhys from the main branch on GitHub


### PR DESCRIPTION
`pymssql` has a new maintainer. They've produced MacOS wheels! :) Yay. So No longer will I need special macos install instructions.