### PR TITLE
[MRG] Change listener to write incoming objects in hierarchy

### DIFF
--- a/lib/pymedphys/_dicom/connect/listen.py
+++ b/lib/pymedphys/_dicom/connect/listen.py
@@ -104,7 +104,7 @@ class DicomListener(DicomConnectBase):
             self.on_released_callback(self.association_directory)
 
     def _build_hierarchical_path_to_series(
-        self, test_dataset: pydicom.dataset.Dataset
+        self, test_dataset: "pydicom.dataset.Dataset"
     ) -> pathlib.Path:
         series_path = pathlib.Path(self.storage_directory).joinpath(
             test_dataset.PatientID,

--- a/lib/pymedphys/tests/dicom/test_connect.py
+++ b/lib/pymedphys/tests/dicom/test_connect.py
@@ -142,19 +142,19 @@ def test_dataset():
     return test_dataset
 
 
-@pytest.mark.dicom
-def test_hierarchical_dicom_storage_directory():
+@pytest.mark.pydicom
+def test_hierarchical_dicom_storage_directory(test_dataset):
     """Test to ensure the constructed directory for storing a DICOM object
     is in the Patient/Study/Series hierarchy that aligns with DICOM Query
     """
-    with tempfile.mkdtemp() as test_dir:
-        expected_directory = test_dir.joinpath(
-            test_dataset.PatientID,
-            test_dataset.StudyInstanceUID,
-            test_dataset.SeriesInstanceUID,
-        )
-        created_directory = hierarchical_dicom_storage_directory(test_dir, test_dataset)
-        assert created_directory == expected_directory
+    test_dir = pathlib.Path(tempfile.mkdtemp())
+    expected_directory = test_dir.joinpath(
+        test_dataset.PatientID,
+        test_dataset.StudyInstanceUID,
+        test_dataset.SeriesInstanceUID,
+    )
+    created_directory = hierarchical_dicom_storage_directory(test_dir, test_dataset)
+    assert created_directory == expected_directory
 
 
 @pytest.mark.pydicom

--- a/lib/pymedphys/tests/dicom/test_connect.py
+++ b/lib/pymedphys/tests/dicom/test_connect.py
@@ -37,7 +37,7 @@ METHOD_MOCK = Mock()
 
 
 def _build_hierarchical_path_to_plan(
-    storage_path: pathlib.Path, test_dataset: pydicom.dataset.Dataset
+    storage_path: pathlib.Path, test_dataset: "pydicom.dataset.Dataset"
 ) -> pathlib.Path:
     file_path = pathlib.Path(storage_path).joinpath(
         test_dataset.PatientID,


### PR DESCRIPTION
hierarchy of patient/study/series/instance
with PatientID for patient directory name
Study and Series Instance UID respectively for study and series directory

this matches the DICOM Q/R hierarchy used for navigational queries (simplifies adding Q/R capabilities with the same hierarchy as the backing store).
It is also useful for applications that look for data in this hierarchy (e.g. DICOMpyler, OnkoDICOM)