### PR TITLE
[RFR] Enable the library tests for the binary

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -194,7 +194,7 @@ jobs:
       if: steps.poetry-cache.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
+        timeout 10s poetry run pip --version || rm -rf .venv
 
 # -----------------------------------------------------------------------------
 

--- a/binary/build-binary.py
+++ b/binary/build-binary.py
@@ -200,13 +200,6 @@ def _install_pymedphys_in_offline_mode(prepend):
         cwd=BUILD_PYTHON_EMBED,
     )
 
-    # Trigger building of matplotlib font cache
-    subprocess.check_call(
-        f'{prepend}python.exe -c "import matplotlib.pyplot as plt"',
-        shell=True,
-        cwd=BUILD_PYTHON_EMBED,
-    )
-
 
 def _create_compressed_python_embed():
     """Compress the created embedded python distribution to a tar.xz file.

--- a/binary/build-binary.py
+++ b/binary/build-binary.py
@@ -200,6 +200,13 @@ def _install_pymedphys_in_offline_mode(prepend):
         cwd=BUILD_PYTHON_EMBED,
     )
 
+    # Trigger building of matplotlib font cache
+    subprocess.check_call(
+        f'{prepend}python.exe -c "import matplotlib.pyplot as plt"',
+        shell=True,
+        cwd=BUILD_PYTHON_EMBED,
+    )
+
 
 def _create_compressed_python_embed():
     """Compress the created embedded python distribution to a tar.xz file.

--- a/binary/build-binary.py
+++ b/binary/build-binary.py
@@ -118,6 +118,16 @@ def _build_and_collate_wheels(prepend):
         shell=True,
         cwd=REPO_ROOT,
     )
+
+    # Recent dev commits remove pylinac gui, delete production pylinac
+    # wheel and test with a recent development commit.
+    WHEELS.joinpath("pylinac-2.3.2-py3-none-any.whl").unlink()
+    subprocess.check_call(
+        f"{prepend}python -m pip wheel git+https://github.com/jrkerns/pylinac.git@446d4cf7fd1999ac1c418765db329f394515d5c0",
+        shell=True,
+        cwd=WHEELS,
+    )
+
     subprocess.check_call("poetry build -f wheel", shell=True, cwd=REPO_ROOT)
 
     pymedphys_wheel = f"pymedphys-{_get_version_string()}-py3-none-any.whl"

--- a/binary/test.py
+++ b/binary/test.py
@@ -56,11 +56,12 @@ def main():
             shell=True,
         )
 
-    # TODO: For now just testing cypress above. Some work needs to be
-    # done re the environment before all tests can be run as below.
-
     subprocess.check_call(
         f"{prepend}cmd.exe /C pymedphys dev tests -v", cwd=BUILD_DIST, shell=True
+    )
+
+    subprocess.check_call(
+        f"{prepend}cmd.exe /C pymedphys dev tests -v --slow", cwd=BUILD_DIST, shell=True
     )
 
 

--- a/binary/test.py
+++ b/binary/test.py
@@ -59,9 +59,9 @@ def main():
     # TODO: For now just testing cypress above. Some work needs to be
     # done re the environment before all tests can be run as below.
 
-    # subprocess.check_call(
-    #     f"{prepend}cmd.exe /C pymedphys dev tests -v", cwd=BUILD_DIST, shell=True
-    # )
+    subprocess.check_call(
+        f"{prepend}cmd.exe /C pymedphys dev tests -v", cwd=BUILD_DIST, shell=True
+    )
 
 
 @contextmanager

--- a/lib/pymedphys/tests/experimental/pinnacle/test_pinnacle_cli.py
+++ b/lib/pymedphys/tests/experimental/pinnacle/test_pinnacle_cli.py
@@ -48,6 +48,7 @@ from zipfile import ZipFile
 import pytest
 
 from pymedphys._data import download
+from pymedphys._utilities import test as pmp_test_utils
 
 working_path = tempfile.mkdtemp()
 data_path = os.path.join(working_path, "data")
@@ -74,21 +75,25 @@ def test_pinnacle_cli_output(data):
 
     for pinn_dir in data.joinpath("Pt1").joinpath("Pinnacle").iterdir():
 
-        command = "pymedphys experimental pinnacle export".split() + [
-            "-o",
-            output_path,
-            "-m",
-            "CT",
-            "-m",
-            "RTSTRUCT",
-            "-m",
-            "RTDOSE",
-            "-m",
-            "RTPLAN",
-            "-t",
-            "Trial_1",
-            pinn_dir.as_posix(),
-        ]
+        command = (
+            [str(pmp_test_utils.get_executable_even_when_embedded()), "-m"]
+            + "pymedphys experimental pinnacle export".split()
+            + [
+                "-o",
+                output_path,
+                "-m",
+                "CT",
+                "-m",
+                "RTSTRUCT",
+                "-m",
+                "RTDOSE",
+                "-m",
+                "RTPLAN",
+                "-t",
+                "Trial_1",
+                pinn_dir.as_posix(),
+            ]
+        )
 
         subprocess.check_call(command)
 
@@ -102,10 +107,11 @@ def test_pinnacle_cli_list(data):
 
     for pinn_dir in data.joinpath("Pt1").joinpath("Pinnacle").iterdir():
 
-        command = "pymedphys experimental pinnacle export".split() + [
-            "-l",
-            pinn_dir.as_posix(),
-        ]
+        command = (
+            [str(pmp_test_utils.get_executable_even_when_embedded()), "-m"]
+            + "pymedphys experimental pinnacle export".split()
+            + ["-l", pinn_dir.as_posix()]
+        )
 
         cli_output = str(subprocess.check_output(command))
         cli_output_parts = cli_output.split("\\n")
@@ -126,13 +132,11 @@ def test_pinnacle_cli_missing_trial(data):
 
     for pinn_dir in data.joinpath("Pt1").joinpath("Pinnacle").iterdir():
 
-        command = "pymedphys experimental pinnacle export".split() + [
-            "-o",
-            output_path,
-            "-t",
-            "nonexistenttrial",
-            pinn_dir.as_posix(),
-        ]
+        command = (
+            [str(pmp_test_utils.get_executable_even_when_embedded()), "-m"]
+            + "pymedphys experimental pinnacle export".split()
+            + ["-o", output_path, "-t", "nonexistenttrial", pinn_dir.as_posix()]
+        )
 
         cli_output = str(subprocess.check_output(command))
         assert "No Trial: nonexistenttrial found in Plan" in cli_output


### PR DESCRIPTION
Well that was unexpected. I was able to get the binary's tests to pass by using a recent commit hash of pylinac. Pylinac recently removed the `py_gui` import from its `__ini__.py` and that's now allowed us to utilise it here.

Hi @pchlap,

To make the pinnacle CLI tests work I needed to prepend the equivalent of `python -m` in front of `pymedphys experimental pinnacle ...etc`.

Would you be able to give this a bit of a look over and make sure you're happy with it? It's a little messy the way I adjusted it, if you have a preference for how to make it work let me know.