### PR TITLE
Move tensorflow out of `_imports` given its own import magic

### DIFF
--- a/lib/pymedphys/_experimental/autosegmentation/pipeline.py
+++ b/lib/pymedphys/_experimental/autosegmentation/pipeline.py
@@ -19,7 +19,7 @@ import pathlib
 
 from pymedphys._imports import numpy as np
 from pymedphys._imports import pydicom
-from pymedphys._imports import tensorflow as tf
+from pymedphys._imports.slow import tensorflow as tf
 
 from pymedphys._data import download
 

--- a/lib/pymedphys/_experimental/autosegmentation/tfrecord.py
+++ b/lib/pymedphys/_experimental/autosegmentation/tfrecord.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from pymedphys._imports import tensorflow as tf
+from pymedphys._imports.slow import tensorflow as tf
 
 
 def _bytes_feature(value):

--- a/lib/pymedphys/_imports/__init__.py
+++ b/lib/pymedphys/_imports/__init__.py
@@ -7,7 +7,7 @@ from pymedphys._vendor import apipkg
 
 HERE = pathlib.Path(__file__).parent
 
-imports_for_apipkg = _parse.parse_imports(HERE)
+imports_for_apipkg = _parse.parse_imports(HERE.joinpath("imports.py"))
 apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
 
 THIS = importlib.import_module(__name__)

--- a/lib/pymedphys/_imports/__init__.py
+++ b/lib/pymedphys/_imports/__init__.py
@@ -1,10 +1,17 @@
+import importlib
 import pathlib
 
-from pymedphys._imports import _magic
+from pymedphys._imports import _parse
+
+from pymedphys._vendor import apipkg
 
 HERE = pathlib.Path(__file__).parent
 
-IMPORTABLES = _magic.import_magic(HERE)
+imports_for_apipkg = _parse.parse_imports(HERE)
+apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
+
+THIS = importlib.import_module(__name__)
+IMPORTABLES = dir(THIS)
 
 # This will never actually run, but it helps pylint know what's going on
 if "numpy" not in IMPORTABLES:

--- a/lib/pymedphys/_imports/_magic.py
+++ b/lib/pymedphys/_imports/_magic.py
@@ -1,0 +1,35 @@
+import ast
+import importlib
+
+from pymedphys._vendor import apipkg
+
+
+def import_magic(import_directory):
+
+    with open(import_directory.joinpath("imports.py")) as f:
+        imports_string = f.read()
+
+    imports_for_apipkg = {}
+
+    for node in ast.parse(imports_string).body:
+        if not isinstance(node, ast.Import):
+            raise ValueError("Only direct import statements are supported")
+
+        aliases = list(node.names)
+        if len(aliases) != 1:
+            raise ValueError("Only one alias per import supported")
+
+        alias = aliases[0]
+        asname = alias.asname
+
+        if asname is None:
+            asname = alias.name
+
+        imports_for_apipkg[asname] = alias.name
+
+    apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
+
+    THIS = importlib.import_module(__name__)
+    IMPORTABLES = dir(THIS)
+
+    return IMPORTABLES

--- a/lib/pymedphys/_imports/_parse.py
+++ b/lib/pymedphys/_imports/_parse.py
@@ -2,7 +2,7 @@ import ast
 
 
 def parse_imports(filepath):
-    """Formulate a dictionary of imports within python file for usage by ``apipkg``.
+    """Formulate a dictionary of imports within a python file for usage by ``apipkg``.
 
     Parameters
     ----------

--- a/lib/pymedphys/_imports/_parse.py
+++ b/lib/pymedphys/_imports/_parse.py
@@ -1,10 +1,7 @@
 import ast
-import importlib
-
-from pymedphys._vendor import apipkg
 
 
-def import_magic(import_directory):
+def parse_imports(import_directory):
 
     with open(import_directory.joinpath("imports.py")) as f:
         imports_string = f.read()
@@ -27,9 +24,4 @@ def import_magic(import_directory):
 
         imports_for_apipkg[asname] = alias.name
 
-    apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
-
-    THIS = importlib.import_module(__name__)
-    IMPORTABLES = dir(THIS)
-
-    return IMPORTABLES
+    return imports_for_apipkg

--- a/lib/pymedphys/_imports/_parse.py
+++ b/lib/pymedphys/_imports/_parse.py
@@ -1,9 +1,21 @@
 import ast
 
 
-def parse_imports(import_directory):
+def parse_imports(filepath):
+    """Formulate a dictionary of imports within python file for usage by ``apipkg``.
 
-    with open(import_directory.joinpath("imports.py")) as f:
+    Parameters
+    ----------
+    filepath
+        The python file containing the imports to be parsed.
+
+    Returns
+    -------
+    imports_for_apipkg
+        A dictionary of imports in the format expected by ``apipkg``.
+
+    """
+    with open(filepath) as f:
         imports_string = f.read()
 
     imports_for_apipkg = {}

--- a/lib/pymedphys/_imports/imports.py
+++ b/lib/pymedphys/_imports/imports.py
@@ -54,7 +54,6 @@ import skimage.measure
 import streamlit
 import streamlit.bootstrap
 import streamlit.cli
-import tensorflow
 
 import libjpeg
 import pydicom

--- a/lib/pymedphys/_imports/slow/__init__.py
+++ b/lib/pymedphys/_imports/slow/__init__.py
@@ -7,7 +7,7 @@ from pymedphys._vendor import apipkg
 
 HERE = pathlib.Path(__file__).parent
 
-imports_for_apipkg = _parse.parse_imports(HERE)
+imports_for_apipkg = _parse.parse_imports(HERE.joinpath("imports.py"))
 apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
 
 THIS = importlib.import_module(__name__)

--- a/lib/pymedphys/_imports/slow/__init__.py
+++ b/lib/pymedphys/_imports/slow/__init__.py
@@ -1,10 +1,17 @@
+import importlib
 import pathlib
 
-from pymedphys._imports import _magic
+from pymedphys._imports import _parse
+
+from pymedphys._vendor import apipkg
 
 HERE = pathlib.Path(__file__).parent
 
-IMPORTABLES = _magic.import_magic(HERE)
+imports_for_apipkg = _parse.parse_imports(HERE)
+apipkg.initpkg(__name__, imports_for_apipkg)  # type: ignore
+
+THIS = importlib.import_module(__name__)
+IMPORTABLES = dir(THIS)
 
 # This will never actually run, but it helps pylint know what's going on
 if "tensorflow" not in IMPORTABLES:

--- a/lib/pymedphys/_imports/slow/__init__.py
+++ b/lib/pymedphys/_imports/slow/__init__.py
@@ -7,7 +7,7 @@ HERE = pathlib.Path(__file__).parent
 IMPORTABLES = _magic.import_magic(HERE)
 
 # This will never actually run, but it helps pylint know what's going on
-if "numpy" not in IMPORTABLES:
+if "tensorflow" not in IMPORTABLES:
     from .imports import *
 
     raise ValueError("This section of code should never run")

--- a/lib/pymedphys/_imports/slow/imports.py
+++ b/lib/pymedphys/_imports/slow/imports.py
@@ -1,0 +1,3 @@
+# pylint: disable = unused-import, reimported, import-error
+
+import tensorflow


### PR DESCRIPTION
Tensorflow importing would bypass pymedphys' `just-in-time` import logic. This would result in slow initial import times across the board. This moves tensorflow into its own `pymedphys._imports.slow` package.