### PR TITLE
Make BB search longer and further

### DIFF
--- a/lib/pymedphys/_experimental/wlutz/findbb.py
+++ b/lib/pymedphys/_experimental/wlutz/findbb.py
@@ -98,7 +98,7 @@ def bb_basinhopping(to_minimise, bb_bounds, initial_bb_centre):
         T=1,
         niter=300,
         niter_success=10,
-        stepsize=1,
+        stepsize=0.2,
         minimizer_kwargs={"method": "L-BFGS-B", "bounds": bb_bounds},
     )
 

--- a/lib/pymedphys/_experimental/wlutz/findbb.py
+++ b/lib/pymedphys/_experimental/wlutz/findbb.py
@@ -96,9 +96,9 @@ def bb_basinhopping(to_minimise, bb_bounds, initial_bb_centre):
         to_minimise,
         initial_bb_centre,
         T=1,
-        niter=200,
-        niter_success=5,
-        stepsize=0.25,
+        niter=300,
+        niter_success=10,
+        stepsize=1,
         minimizer_kwargs={"method": "L-BFGS-B", "bounds": bb_bounds},
     )
 


### PR DESCRIPTION
The washed out FFF images are hard... But it is helpful for them to work. Under the hood the BB algorithm repeats 6 times, each time with slightly different input parameters. Each result needs to be within 0.2 mm of the initial result otherwise it raises an error and doesn't produce a result at all.

The washed out FFF images have a barely visible ball bearing. Nevertheless, the algorithm can find them. Hopefully by increasing the global optimiser iterations it will be able to be found more consistently.

I'm going to hit rerun a few times here to make sure it really is now consistently finding it. The tests have already passed once, will rerun a few more times before requesting review.