### PR TITLE
Pylint skip coll

### DIFF
--- a/lib/pymedphys/_experimental/streamlit/apps/collimator_corrections.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/collimator_corrections.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: skip-file
+
 from pymedphys._imports import numpy as np
 from pymedphys._imports import pandas as pd
 from pymedphys._imports import plt


### PR DESCRIPTION
That collimator correction code is so bad it intermittently sends pylint into recursive loops :sweat_smile:

https://github.com/pymedphys/pymedphys/runs/1654556093#step:35:1505

...so... this skips pylint on that file for now...