### PR TITLE
Fix barebones config

### DIFF
--- a/lib/pymedphys/_streamlit/apps/metersetmap/config.toml
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/config.toml
@@ -8,13 +8,13 @@ default_reference = "dicom"
 default_evaluation = "trf"
 
 [[site]]
-name = "default-site-name"
+name = "a-demo-site-name"
 
     [site.export-directories]
-    escan = '~/mudensity-demo/pdf'
+    escan = '~/pymedphys-gui-metersetmap'
 
 [output]
-png_directory = '~/mudensity-demo/png'
+png_directory = '~/pymedphys-gui-metersetmap'
 
 [gamma]
 dose_percent_threshold = 2


### PR DESCRIPTION
See https://pymedphys.discourse.group/t/mlc-position-data-in-trf-file/93/3?u=simonbiggs for the error being fixed.