### PR TITLE
[STACK online-ci -> base] Add CI for testing the live instance of https://app.pymedphys.com

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -1,10 +1,8 @@
 name: Heroku
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  schedule:
+    - cron:  '*/15 * * * *'
 
 jobs:
   OnlineApp:

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -19,4 +19,3 @@ jobs:
           yarn
           export CYPRESS_PYMEDPHYS_GUI_URL="https://app.pymedphys.com"
           yarn cypress run
-        working-directory: ./lib/pymedphys/tests/e2e

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -17,5 +17,6 @@ jobs:
       - name: Install and Run Cypress
         run: |
           yarn
+          export CYPRESS_PYMEDPHYS_GUI_URL="https://app.pymedphys.com"
           yarn cypress run
         working-directory: ./lib/pymedphys/tests/e2e

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -10,6 +10,7 @@ jobs:
   OnlineApp:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '14'

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           yarn
           export CYPRESS_PYMEDPHYS_GUI_URL="https://app.pymedphys.com"
-          yarn cypress run
+          yarn cypress run --spec cypress/integration/streamlit/metersetmap.spec.js
         working-directory: lib/pymedphys/tests/e2e

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -19,3 +19,4 @@ jobs:
           yarn
           export CYPRESS_PYMEDPHYS_GUI_URL="https://app.pymedphys.com"
           yarn cypress run
+        working-directory: lib/pymedphys/tests/e2e

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -1,0 +1,21 @@
+name: Heroku
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  OnlineApp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+
+      - name: Install and Run Cypress
+        run: |
+          yarn
+          yarn cypress run
+        working-directory: ./lib/pymedphys/tests/e2e

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -1,4 +1,4 @@
-name: All
+name: Library
 
 on:
   push:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,6 +59,7 @@
     "Firefox",
     "GUIs",
     "Hacky",
+    "Heroku",
     "Hippocampus",
     "ICOM",
     "IEXEC",

--- a/lib/pymedphys/tests/e2e/cypress/support/commands.js
+++ b/lib/pymedphys/tests/e2e/cypress/support/commands.js
@@ -30,6 +30,16 @@
 
 import 'cypress-file-upload';
 
+function getBaseUrl() {
+  let url = Cypress.env('PYMEDPHYS_GUI_URL')
+  if (url === undefined) {
+    url = "http://localhost:8501"
+  }
+
+  return url
+}
+
+
 
 Cypress.Commands.add('compute', () => {
   let start = new Date().getTime();
@@ -56,13 +66,14 @@ Cypress.Commands.add('textMatch', (label, length, result) => {
 })
 
 Cypress.Commands.add('start', (app) => {
-  cy.visit('http://localhost:8501')
+  let url = getBaseUrl()
+  cy.visit(url)
 
   Cypress.Cookies.defaults({
     preserve: ["_xsrf"]
   });
 
-  cy.visit(`http://localhost:8501/?app=${app}`);
+  cy.visit(`${url}/?app=${app}`);
   cy.compute()
 
   // From https://github.com/streamlit/streamlit/blob/a03d3b9ae3c43a63b149dd590f8f6cf17ec917dd/e2e/specs/component_template.spec.js#L41-L42


### PR DESCRIPTION
Made a CI test for the online app. It serves two purposes, one is to keep the online app "pre-heated" so that it is always booted and ready, the other is to run our CI within the online environment.

For now, I am only running metersetmap tests. In another PR we can get the psuedonymise tests working.