### PR TITLE
Add a seed to the random noise notebook

### DIFF
--- a/lib/pymedphys/docs/howto/gamma/effect-of-noise.ipynb
+++ b/lib/pymedphys/docs/howto/gamma/effect-of-noise.ipynb
@@ -258,6 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "np.random.seed(0)\n",
     "dose_eval_noise = (\n",
     "    dose_eval + \n",
     "    np.random.normal(loc=0, scale=noise, size=np.shape(dose_eval))\n",
@@ -377,7 +378,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
So that the `docs` branch doesn't explode with images from all the notebook re-runs