### PR TITLE
[STACK cypress -> base] Make `pymedphys dev cypress` command

### DIFF
--- a/lib/pymedphys/_dev/tests.py
+++ b/lib/pymedphys/_dev/tests.py
@@ -17,6 +17,7 @@ import pathlib
 import subprocess
 
 import pymedphys._utilities.test as pmp_test_utils
+import pymedphys.tests.e2e.test_cypress as cypress_test_suite
 
 LIBRARY_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 PYLINT_RC_FILE = LIBRARY_ROOT.joinpath(".pylintrc")
@@ -76,3 +77,7 @@ def run_pylint(_, remaining):
         subprocess.check_call(command)
     finally:
         os.chdir(original_cwd)
+
+
+def run_cypress(_):
+    cypress_test_suite.run_test_commands_with_gui_process(["yarn cypress open"])

--- a/lib/pymedphys/_dev/tests.py
+++ b/lib/pymedphys/_dev/tests.py
@@ -1,3 +1,4 @@
+# Copyright (C) 2021 Cancer Care Associates, Simon Biggs
 # Copyright (C) 2020 Simon Biggs
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +18,7 @@ import pathlib
 import subprocess
 
 import pymedphys._utilities.test as pmp_test_utils
-import pymedphys.tests.e2e.test_cypress as cypress_test_suite
+import pymedphys.tests.e2e.utilities as cypress_test_utilities
 
 LIBRARY_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 PYLINT_RC_FILE = LIBRARY_ROOT.joinpath(".pylintrc")
@@ -80,4 +81,4 @@ def run_pylint(_, remaining):
 
 
 def run_cypress(_):
-    cypress_test_suite.run_test_commands_with_gui_process(["yarn cypress open"])
+    cypress_test_utilities.run_test_commands_with_gui_process(["yarn cypress open"])

--- a/lib/pymedphys/cli/dev.py
+++ b/lib/pymedphys/cli/dev.py
@@ -9,6 +9,7 @@ def dev_cli(subparsers):
     add_lint_parser(dev_subparsers)
     add_propagate_parser(dev_subparsers)
     add_doctests_parser(dev_subparsers)
+    add_cypress_parser(dev_subparsers)
 
     return dev_parser
 
@@ -55,3 +56,8 @@ def add_propagate_parser(dev_subparsers):
     )
 
     parser.set_defaults(func=propagate.propagate_all)
+
+
+def add_cypress_parser(dev_subparsers):
+    parser = dev_subparsers.add_parser("cypress")
+    parser.set_defaults(func=tests.run_cypress)

--- a/lib/pymedphys/tests/e2e/test_cypress.py
+++ b/lib/pymedphys/tests/e2e/test_cypress.py
@@ -23,6 +23,19 @@ import pymedphys._utilities.test as pmp_test_utils
 HERE = pathlib.Path(__file__).parent.resolve()
 
 
+def run_test_commands_with_gui_process(commands):
+    gui_command = [
+        pmp_test_utils.get_executable_even_when_embedded(),
+        "-m",
+        "pymedphys",
+        "gui",
+    ]
+
+    with pmp_test_utils.process(gui_command, cwd=HERE):
+        for command in commands:
+            subprocess.check_call(command, cwd=HERE, shell=True)
+
+
 @pytest.mark.cypress
 def test_cypress():
     pymedphys.zip_data_paths("metersetmap-gui-e2e-data.zip", extract_directory=HERE)
@@ -32,14 +45,4 @@ def test_cypress():
         extract_directory=HERE.joinpath("cypress", "fixtures"),
     )
 
-    command = [
-        pmp_test_utils.get_executable_even_when_embedded(),
-        "-m",
-        "pymedphys",
-        "gui",
-    ]
-
-    with pmp_test_utils.process(command, cwd=HERE):
-        subprocess.check_call("yarn", cwd=HERE, shell=True)
-
-        subprocess.check_call("yarn cypress run", cwd=HERE, shell=True)
+    run_test_commands_with_gui_process(["yarn", "yarn cypress run"])

--- a/lib/pymedphys/tests/e2e/test_cypress.py
+++ b/lib/pymedphys/tests/e2e/test_cypress.py
@@ -15,7 +15,7 @@
 import pathlib
 import subprocess
 
-import pytest
+from pymedphys._imports import pytest
 
 import pymedphys
 import pymedphys._utilities.test as pmp_test_utils

--- a/lib/pymedphys/tests/e2e/utilities.py
+++ b/lib/pymedphys/tests/e2e/utilities.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Cancer Care Associates
+# Copyright (C) 2021 Cancer Care Associates
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,22 +13,22 @@
 # limitations under the License.
 
 
-import pytest
+import pathlib
+import subprocess
 
-import pymedphys
+import pymedphys._utilities.test as pmp_test_utils
 
-from . import utilities
+HERE = pathlib.Path(__file__).parent.resolve()
 
 
-@pytest.mark.cypress
-def test_cypress():
-    pymedphys.zip_data_paths(
-        "metersetmap-gui-e2e-data.zip", extract_directory=utilities.HERE
-    )
+def run_test_commands_with_gui_process(commands):
+    gui_command = [
+        pmp_test_utils.get_executable_even_when_embedded(),
+        "-m",
+        "pymedphys",
+        "gui",
+    ]
 
-    pymedphys.zip_data_paths(
-        "dummy-ct-and-struct.zip",
-        extract_directory=utilities.HERE.joinpath("cypress", "fixtures"),
-    )
-
-    utilities.run_test_commands_with_gui_process(["yarn", "yarn cypress run"])
+    with pmp_test_utils.process(gui_command, cwd=HERE):
+        for command in commands:
+            subprocess.check_call(command, cwd=HERE, shell=True)


### PR DESCRIPTION
It starts up the PyMedPhys GUI server in the background and then boots up the interactive e2e testing suite, cypress.