### PR TITLE
Monkey patch for PyLinac's Python 3.9 incompatibility

### DIFF
--- a/lib/pymedphys/_experimental/vendor/pylinac_vendored/_pylinac_installed.py
+++ b/lib/pymedphys/_experimental/vendor/pylinac_vendored/_pylinac_installed.py
@@ -1,4 +1,9 @@
+import collections
 import sys
+from collections.abc import Iterable, Sequence
+
+collections.Iterable = Iterable  # type: ignore
+collections.Sequence = Sequence  # type: ignore
 
 from . import py_gui, watcher
 


### PR DESCRIPTION
This should remove the following warning messages:

```
..\..\.venv\lib\site-packages\pylinac\core\utilities.py:2
  C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\pylinac\core\utilities.py:2: DeprecationWarning: Using or import working
    from collections import Iterable

..\..\.venv\lib\site-packages\pylinac\picketfence.py:15
  C:\Users\sbiggs\git\pymedphys\.venv\lib\site-packages\pylinac\picketfence.py:15: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Sequence
```