### PR TITLE
Make lock conflicts revert to main initially

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -42,9 +42,7 @@ jobs:
       - name: Install PyMedPhys with propagate environment
         if: steps.conflicts.outputs.status == 'true'
         run: |
-          poetry install -E propagate
-          pip install pipx
-          pipx install poetry-merge-lock
+          poetry install -E propagate || poetry lock --no-updates && poetry install -E propagate
 
       - name: Fix conflicts
         if: steps.conflicts.outputs.status == 'true'
@@ -55,7 +53,7 @@ jobs:
           git fetch origin main
           git merge origin/main || true
 
-          poetry run pymedphys dev propagate || poetry-merge-lock && poetry run pymedphys dev propagate
+          poetry run pymedphys dev propagate || git checkout main poetry.lock && poetry run pymedphys dev propagate
 
           git add poetry.lock setup.py requirements* pyproject.hash
           git commit -m "Merge origin/main, fix merge conflicts from 'pymedphys dev propagate'"


### PR DESCRIPTION
The lock file will then be updated for any new dependencies with propagate. The only downside of this approach that I can see is that when trying to run "poetry update". If that causes conflicts with the current main branch it'll revert the update.

However, those who are doing upgrades should instead first merge main, make sure there are no conflicts, and then run the update. Given only maintainers really should be running upgrades this seems like a fine compromise.