### PR TITLE
Change `download` to accept file content instead of file path

### DIFF
--- a/lib/pymedphys/_experimental/streamlit/apps/download.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/download.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import pathlib
 
 from pymedphys._imports import streamlit as st
@@ -34,3 +35,6 @@ def main():
     filepath = THIS
 
     download(filename, filepath)
+
+    buffer = io.BytesIO("Some beautiful text!".encode())
+    download("a_text_file.txt", buffer)

--- a/lib/pymedphys/_experimental/streamlit/apps/download.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/download.py
@@ -29,8 +29,12 @@ THIS = pathlib.Path(__file__).resolve()
 
 def main():
     st.write(
-        "This is a demo Streamlit app showing how to use the `download()` function"
+        "This is a demo Streamlit app showing how to use the "
+        "`download` function. The docstring for the "
+        "`download` function is as follows:"
     )
+
+    st.code(download.__doc__)
 
     st.write("## Download this very Python file")
 

--- a/lib/pymedphys/_experimental/streamlit/apps/download.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/download.py
@@ -15,6 +15,7 @@
 import io
 import pathlib
 
+from pymedphys._imports import plt
 from pymedphys._imports import streamlit as st
 
 from pymedphys._streamlit import categories
@@ -31,10 +32,24 @@ def main():
         "This is a demo Streamlit app showing how to use the `download()` function"
     )
 
-    filename = THIS.name
-    filepath = THIS
+    with open(THIS) as f:
+        # Download this very Python file
+        download(THIS.name, f.read())
 
-    download(filename, filepath)
+    download("a_text_file.txt", "Some beautiful text!")
 
-    buffer = io.BytesIO("Some beautiful text!".encode())
-    download("a_text_file.txt", buffer)
+    buffer = io.BytesIO()
+    fig, ax = plt.subplots()
+
+    left, right = st.beta_columns(2)
+
+    ax.plot([0, 1, 2], [1, -1, 1])
+
+    with left:
+        st.pyplot(fig)
+
+    fig.savefig(buffer, format="png")
+    buffer.seek(0)
+
+    with right:
+        download("plot.png", buffer.read())

--- a/lib/pymedphys/_experimental/streamlit/apps/download.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/download.py
@@ -32,24 +32,29 @@ def main():
         "This is a demo Streamlit app showing how to use the `download()` function"
     )
 
+    st.write("## Download this very Python file")
+
     with open(THIS) as f:
-        # Download this very Python file
         download(THIS.name, f.read())
 
+    st.write("## Download a text file")
     download("a_text_file.txt", "Some beautiful text!")
 
-    buffer = io.BytesIO()
-    fig, ax = plt.subplots()
-
+    st.write("## Download a matplotlib figure")
     left, right = st.beta_columns(2)
 
-    ax.plot([0, 1, 2], [1, -1, 1])
+    fig, ax = plt.subplots()
+    ax.plot([-1, 0, 1], [1, -1, 1])
 
     with left:
         st.pyplot(fig)
 
-    fig.savefig(buffer, format="png")
-    buffer.seek(0)
-
     with right:
-        download("plot.png", buffer.read())
+        _download_figure("plot.png", fig)
+
+
+def _download_figure(name, fig):
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format=name.split(".")[-1])
+    buffer.seek(0)
+    download(name, buffer.read())

--- a/lib/pymedphys/_experimental/streamlit/apps/download.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/download.py
@@ -36,15 +36,17 @@ def main():
 
     st.code(download.__doc__)
 
-    st.write("## Download this very Python file")
+    st.write("## Example uses of `download`")
+
+    st.write("### Download this very Python file")
 
     with open(THIS) as f:
         download(THIS.name, f.read())
 
-    st.write("## Download a text file")
+    st.write("### Download a text file")
     download("a_text_file.txt", "Some beautiful text!")
 
-    st.write("## Download a matplotlib figure")
+    st.write("### Download a matplotlib figure")
     left, right = st.beta_columns(2)
 
     fig, ax = plt.subplots()

--- a/lib/pymedphys/_gui.py
+++ b/lib/pymedphys/_gui.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Tuple
 from pymedphys._imports import streamlit as st
 from pymedphys._imports import tornado
 
-from pymedphys._streamlit.server import session
+from pymedphys._streamlit.server import downloads
 
 HERE = pathlib.Path(__file__).parent.resolve()
 STREAMLIT_CONTENT_DIR = HERE.joinpath("_streamlit")
@@ -56,8 +56,8 @@ def _create_handlers() -> Handlers:
     class DownloadHandler(  # pylint: disable = abstract-method
         tornado.web.RequestHandler
     ):
-        def get(self, session_id: uuid.UUID, filename: str):
-            file_bytes = session.get_download_file(session_id, filename)
+        def get(self, session_id: uuid.UUID, name: str):
+            file_bytes = downloads.get_download_file(session_id, name)
 
             self.write(file_bytes)
             self.finish()

--- a/lib/pymedphys/_imports/imports.py
+++ b/lib/pymedphys/_imports/imports.py
@@ -74,6 +74,7 @@ import streamlit
 import streamlit.bootstrap
 import streamlit.cli
 import streamlit.config
+import streamlit.report_session
 import streamlit.server
 import streamlit.server.server
 import streamlit.server.server_util

--- a/lib/pymedphys/_streamlit/server/downloads.py
+++ b/lib/pymedphys/_streamlit/server/downloads.py
@@ -12,68 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
-import pathlib
-from typing import Dict
-
 from pymedphys._imports import streamlit as st
 
-from .session import SessionID, get_session_id
-
-FileName = str
-FilePath = pathlib.Path
-FileLocationMap = Dict[SessionID, Dict[FileName, FilePath]]
+from . import session
 
 
-# Assuming CPython with the GIL is being used. This implies that Dicts
-# are thread-safe:
-#
-#    <https://docs.python.org/3/glossary.html#term-global-interpreter-lock>
-
-# More info regarding thread-safety of default-dict:
-#
-# <https://stackoverflow.com/a/17682555/3912576>
-
-# Importantly this assumption only applies if __hash__ and __eq__ of the
-# keys don't call Python. Keys here are of str type, so OK.
-
-# Nevertheless... placing a lock around this object, or utilising a
-# Queue, in its final implementation would be prudent.
-
-file_location_map: FileLocationMap = collections.defaultdict(dict)
-
-# TODO: Adjust this object later to hook into when Streamlit sessions
-# are closed. Potentially utilise an object similar to, or based on,
-# session state objects?
-
-
-def download(filename: str, filepath: pathlib.Path):
+def download(name: str, file: session.File):
     """Create a Streamlit download link to a given file.
 
     Parameters
     ----------
-    filename : str
+    name : str
         The filename of the download. If a previous download link has
         been provided with the same download name the previous filepath
         will be overwritten.
-    filepath : pathlib.Path
-        The full filepath of the file to be downloaded.
+    file : pathlib.Path, str, or io.BytesIO
+        The file to be downloaded.
     """
 
-    url = _add_filepath_get_url(filename, filepath)
+    url = _add_file_get_url(name, file)
 
     href = f"""
-        <a href="{url}" download='{filename}'>
-            Click to download `{filename}`
+        <a href="{url}" download='{name}'>
+            Click to download `{name}`
         </a>
     """
     st.markdown(href, unsafe_allow_html=True)
 
 
-def _add_filepath_get_url(filename: str, filepath: pathlib.Path):
-    session_id = get_session_id()
+def _add_file_get_url(filename: str, file: session.File):
+    session_id = session.get_session_id()
     url = f"downloads/{session_id}/{filename}"
 
-    file_location_map[session_id][filename] = filepath
+    session.set_download_file(filename, file)
 
     return url

--- a/lib/pymedphys/_streamlit/server/downloads.py
+++ b/lib/pymedphys/_streamlit/server/downloads.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pathlib
+from typing import BinaryIO, Union
+
 from pymedphys._imports import streamlit as st
 
 from . import session
 
+File = Union[pathlib.Path, str, BinaryIO]
 
-def download(name: str, file: session.File):
+
+def download(name: str, file: File):
     """Create a Streamlit download link to a given file.
 
     Parameters
@@ -40,7 +45,7 @@ def download(name: str, file: session.File):
     st.markdown(href, unsafe_allow_html=True)
 
 
-def _add_file_get_url(filename: str, file: session.File):
+def _add_file_get_url(filename: str, file: File) -> str:
     session_id = session.get_session_id()
     url = f"downloads/{session_id}/{filename}"
 

--- a/lib/pymedphys/_streamlit/server/downloads.py
+++ b/lib/pymedphys/_streamlit/server/downloads.py
@@ -23,7 +23,7 @@ FileContent = Union[str, bytes]
 
 
 def download(name: str, content: FileContent):
-    """Create a Streamlit download link to a given file.
+    """Create a Streamlit download link to the given file content.
 
     Parameters
     ----------

--- a/lib/pymedphys/_streamlit/server/session.py
+++ b/lib/pymedphys/_streamlit/server/session.py
@@ -16,11 +16,14 @@
 # It is understood that we are stepping into 'private' API usage here
 # pylint: disable = protected-access
 
+import io
+import pathlib
 import uuid
+from typing import BinaryIO, Union, cast
+
+File = Union[pathlib.Path, str, BinaryIO]
 
 from pymedphys._imports import streamlit as st
-
-SessionID = uuid.UUID
 
 
 class SessionState:
@@ -36,23 +39,51 @@ class SessionState:
                 setattr(self, key, val)
 
 
-def get_session_id() -> SessionID:
+def get_session_id() -> uuid.UUID:
     ctx = st.report_thread.get_report_ctx()
-    session_id: SessionID = ctx.session_id
+    session_id: uuid.UUID = ctx.session_id
 
     return session_id
 
 
-def get_session():
-    session_id = get_session_id()
-    return st.server.server.Server.get_current()._get_session_info(session_id).session
+def get_session(session_id: uuid.UUID = None) -> "st.report_session.ReportSession":
+    if session_id is None:
+        session_id = get_session_id()
+
+    report_session: st.report_session.ReportSession = (
+        st.server.server.Server.get_current()._get_session_info(session_id).session
+    )
+    return report_session
+
+
+def get_download_file(session_id: uuid.UUID, filename: str) -> bytes:
+    session = get_session(session_id=session_id)
+    file: File = session.downloads[filename]
+
+    if isinstance(file, io.BytesIO):
+        return file.read()
+
+    filepath = cast(Union[pathlib.Path, str], file)
+
+    with open(filepath, "rb") as fh:
+        return fh.read()
+
+
+def set_download_file(filename, file: File):
+    session = get_session()
+
+    try:
+        session.downloads[filename] = file
+    except AttributeError:
+        session.downloads = {filename: file}
 
 
 def session_state(**state):
     session = get_session()
-    if hasattr(session, "_custom_session_state"):
+
+    try:
         session._custom_session_state.update(state)
-    else:
+    except AttributeError:
         session._custom_session_state = SessionState(state)
 
     return session._custom_session_state

--- a/lib/pymedphys/_streamlit/server/session.py
+++ b/lib/pymedphys/_streamlit/server/session.py
@@ -21,9 +21,9 @@ import pathlib
 import uuid
 from typing import BinaryIO, Union, cast
 
-File = Union[pathlib.Path, str, BinaryIO]
-
 from pymedphys._imports import streamlit as st
+
+File = Union[pathlib.Path, str, BinaryIO]
 
 
 class SessionState:

--- a/lib/pymedphys/_streamlit/server/session.py
+++ b/lib/pymedphys/_streamlit/server/session.py
@@ -16,10 +16,9 @@
 # It is understood that we are stepping into 'private' API usage here
 # pylint: disable = protected-access
 
-import io
 import pathlib
 import uuid
-from typing import BinaryIO, Union, cast
+from typing import BinaryIO, Union
 
 from pymedphys._imports import streamlit as st
 
@@ -54,28 +53,6 @@ def get_session(session_id: uuid.UUID = None) -> "st.report_session.ReportSessio
         st.server.server.Server.get_current()._get_session_info(session_id).session
     )
     return report_session
-
-
-def get_download_file(session_id: uuid.UUID, filename: str) -> bytes:
-    session = get_session(session_id=session_id)
-    file: File = session.downloads[filename]
-
-    if isinstance(file, io.BytesIO):
-        return file.read()
-
-    filepath = cast(Union[pathlib.Path, str], file)
-
-    with open(filepath, "rb") as fh:
-        return fh.read()
-
-
-def set_download_file(filename, file: File):
-    session = get_session()
-
-    try:
-        session.downloads[filename] = file
-    except AttributeError:
-        session.downloads = {filename: file}
 
 
 def session_state(**state):

--- a/lib/pymedphys/tests/e2e/cypress/integration/streamlit/download.spec.js
+++ b/lib/pymedphys/tests/e2e/cypress/integration/streamlit/download.spec.js
@@ -9,12 +9,21 @@ describe("When running the demo downloads app", () => {
     });
 
     it("should be able to download `download.py` and have the appropriate copyright header.", () => {
-        cy.get('a').contains('Click to download').click()
+        cy.get('a').contains('download.py').click()
         const filename = path.join(downloadsFolder, 'download.py')
 
         cy.readFile(filename).should((text) => {
             const lines = text.split('\n')
             expect(lines[0]).to.contain("# Copyright (C) 2021 Cancer Care Associates")
+        })
+    });
+
+    it("should be able to download `a_text_file.txt` and have the appropriate contents.", () => {
+        cy.get('a').contains('a_text_file.txt').click()
+        const filename = path.join(downloadsFolder, 'a_text_file.txt')
+
+        cy.readFile(filename).should((text) => {
+            expect(text).to.contain("Some beautiful text!")
         })
     });
 });


### PR DESCRIPTION
@Matthew-Jennings she's good to go :slightly_smiling_face:. Here is a newly pressed `download()` function that can also accept `BinaryIO` :slightly_smiling_face:. 

---

[EDIT]The below comments are now out of date, see https://github.com/pymedphys/pymedphys/pull/1411#issuecomment-774367070 [/EDIT]

I'm not so convinced with the API. I feel like people are going to want to write something like:

```python
download("a_file.txt", "Some awesome content")
```

Except that there won't work in it's current form. They would have to do:

```python
import io
download("a_file.txt", io.BinaryIO("Some awesome contents".encode()))
```

...quite convoluted.

So ideally, the function can be passed a string. ...but a string is currently assumed to be a path.

...maybe... the best approach actually would be to never let it be a path. But always be file contents. That way, if a path is actually wanted then the user would need to write:

```python
with open('path/to/file') as f:
    download(filename, f.read())
```

People are used to that pattern... it also has the added benefit of "failing fast", meaning if the filepath provided to `download` doesn't exist, it fails when `download` is called. But also, now the following would work:


```python
import tempfile
import pathlib

with tempfile.TemporaryDirectory() as dir:
	path = pathlib.Path(dir, 'a_file')
	... do stuff
    download(filename, path)

... more things
```

In the current design of `download` if the above was used as an approach even if the `download` code had some sort of sanity "check if file exists" code, it would still think everything was okay... until the user goes to click the link the file would no longer be there and it would error out.

Instead, by requiring the content of the file to always be passed to `download` even if the file no longer exists on disk when the user goes to click on it, still the user will get the version of the file as it existed when `download` was called within the streamlit app.