### PR TITLE
Allow setting the bind IP address for the listen CLI

### DIFF
--- a/lib/pymedphys/_dicom/connect/listen.py
+++ b/lib/pymedphys/_dicom/connect/listen.py
@@ -193,7 +193,10 @@ def listen_cli(args):
 
     # Start the listener
     dicom_listener = DicomListener(
-        port=args.port, ae_title=args.aetitle, storage_directory=args.storage_directory
+        host=args.bind,
+        port=args.port,
+        ae_title=args.aetitle,
+        storage_directory=args.storage_directory,
     )
     dicom_listener.start()
 

--- a/lib/pymedphys/cli/dicom.py
+++ b/lib/pymedphys/cli/dicom.py
@@ -239,6 +239,9 @@ def listen(dicom_subparsers):
     )
 
     parser.add_argument("port", type=int, help="The port on which to listen")
+    parser.add_argument(
+        "-b", "--bind", default="0.0.0.0", type=str, help="The IP address to bind to"
+    )
     parser.add_argument("-d", "--storage_directory", default=".", type=str, help="")
     parser.add_argument(
         "-a",


### PR DESCRIPTION
Hi @sjswerdloff 

this is an attempt at a fairly minimal fix to #1432. My thinking here was that if we bind to 0.0.0.0 by default then that would usually be the desired behaviour. In case the user wants to bind to a specific IP address, they can now do this with a command line option.

I think this should work, note that I haven't been able to test this on Windows. I also don't know how to make a unit test which confirms the resolution of this issue.

This further highlights the issue you raised in #1431, that there is no separation between the SCU and SCP IP/host. I'd be happy to look into how to best do that here, or possibly leaven that for the larger #1431 pull request.

Looking forward to hearing what you think.