### PR TITLE
Add cypress docker option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,17 +63,10 @@ RUN pyenv global $PYTHON_VERSION
 RUN python -m pip install --upgrade wheel pip
 RUN pyenv rehash
 
-COPY --from=downloads /root/.pymedphys /root/.pymedphys
-
 COPY requirements-deploy.txt /pymedphys/requirements-deploy.txt
 RUN python -m pip install -r /pymedphys/requirements-deploy.txt
 
-COPY lib /pymedphys/lib
-COPY setup.py  /pymedphys/setup.py
-RUN python -m pip install -e /pymedphys/.[user,tests]
-RUN pyenv rehash
-
-COPY . /pymedphys
+COPY --from=downloads /root/.pymedphys /root/.pymedphys
 COPY --from=dos2unix /pymedphys/docker /pymedphys/docker
 
 EXPOSE 8501
@@ -87,5 +80,12 @@ COPY --from=build /root/wrapper.so /root/wrapper.so
 RUN \
     LD_PRELOAD=/root/wrapper.so /opt/mssql/bin/sqlservr & \
     /pymedphys/docker/wait-for-it.sh localhost:1433 -t 120
+
+COPY lib /pymedphys/lib
+COPY setup.py  /pymedphys/setup.py
+RUN python -m pip install -e /pymedphys/.[user,tests]
+RUN pyenv rehash
+
+COPY . /pymedphys
 
 CMD [ "/pymedphys/docker/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN gcc -shared  -ldl -fPIC -o wrapper.so wrapper.c
 
 
 FROM debian:stretch-slim AS dos2unix
-# Adapted from https://github.com/justin2004/mssql_server_tiny/blob/7ca5bc1eb3a302d43030c45206bf3d64da34b1d1/Dockerfile
 WORKDIR /root
 
 RUN apt-get update && apt-get install -y dos2unix

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ COPY requirements-deploy.txt /pymedphys/requirements-deploy.txt
 RUN python -m pip install -r /pymedphys/requirements-deploy.txt
 
 COPY --from=downloads /root/.pymedphys /root/.pymedphys
-COPY --from=dos2unix /pymedphys/docker /pymedphys/docker
 
 EXPOSE 8501
 
@@ -76,6 +75,7 @@ ENV ACCEPT_EULA=Y \
     MSSQL_MEMORY_LIMIT_MB=128
 
 COPY --from=build /root/wrapper.so /root/wrapper.so
+COPY --from=dos2unix /pymedphys/docker /pymedphys/docker
 
 RUN \
     LD_PRELOAD=/root/wrapper.so /opt/mssql/bin/sqlservr & \
@@ -83,9 +83,10 @@ RUN \
 
 COPY lib /pymedphys/lib
 COPY setup.py  /pymedphys/setup.py
-RUN python -m pip install -e /pymedphys/.[user,tests]
+RUN python -m pip install -e /pymedphys/.
 RUN pyenv rehash
 
 COPY . /pymedphys
+COPY --from=dos2unix /pymedphys/docker /pymedphys/docker
 
 CMD [ "/pymedphys/docker/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ RUN pyenv global $PYTHON_VERSION
 RUN python -m pip install --upgrade wheel pip
 RUN pyenv rehash
 
+RUN pip install pymedphys tqdm
+COPY lib/pymedphys/_data $HOME/.pyenv/versions/$PYTHON_VERSION\lib\site-packages\pymedphys\_data
+COPY docker/download.py /pymedphys/docker/download.py
+RUN python /pymedphys/docker/download.py
+RUN pip uninstall pymedphys -y
+
 COPY requirements-deploy.txt /pymedphys/requirements-deploy.txt
 RUN python -m pip install -r /pymedphys/requirements-deploy.txt
 

--- a/lib/pymedphys/__init__.py
+++ b/lib/pymedphys/__init__.py
@@ -1,18 +1,14 @@
 """Module docstring."""
 
+from . import dicom, metersetmap, mosaiq, mudensity, trf
 from ._data import data_path, zenodo_data_paths, zip_data_paths
+from ._delivery import Delivery
+from ._gamma.implementation.shell import gamma_shell as gamma
+from ._trf.decode import read_trf as _read_trf
+from ._vendor.deprecated import deprecated as _deprecated
+from ._version import __version__, version_info
 
-try:
-    from . import dicom, metersetmap, mosaiq, mudensity, trf
-    from ._delivery import Delivery
-    from ._gamma.implementation.shell import gamma_shell as gamma
-    from ._trf.decode import read_trf as _read_trf
-    from ._vendor.deprecated import deprecated as _deprecated
-    from ._version import __version__, version_info
-
-    _read_trf.__name__ = "pymedphys.read_trf"
-    read_trf = _deprecated(reason="This has been replaced with `pymedphys.trf.read`")(
-        _read_trf
-    )
-except ImportError:
-    pass
+_read_trf.__name__ = "pymedphys.read_trf"
+read_trf = _deprecated(reason="This has been replaced with `pymedphys.trf.read`")(
+    _read_trf
+)

--- a/lib/pymedphys/__init__.py
+++ b/lib/pymedphys/__init__.py
@@ -1,14 +1,18 @@
 """Module docstring."""
 
-from . import dicom, metersetmap, mosaiq, mudensity, trf
 from ._data import data_path, zenodo_data_paths, zip_data_paths
-from ._delivery import Delivery
-from ._gamma.implementation.shell import gamma_shell as gamma
-from ._trf.decode import read_trf as _read_trf
-from ._vendor.deprecated import deprecated as _deprecated
-from ._version import __version__, version_info
 
-_read_trf.__name__ = "pymedphys.read_trf"
-read_trf = _deprecated(reason="This has been replaced with `pymedphys.trf.read`")(
-    _read_trf
-)
+try:
+    from . import dicom, metersetmap, mosaiq, mudensity, trf
+    from ._delivery import Delivery
+    from ._gamma.implementation.shell import gamma_shell as gamma
+    from ._trf.decode import read_trf as _read_trf
+    from ._vendor.deprecated import deprecated as _deprecated
+    from ._version import __version__, version_info
+
+    _read_trf.__name__ = "pymedphys.read_trf"
+    read_trf = _deprecated(reason="This has been replaced with `pymedphys.trf.read`")(
+        _read_trf
+    )
+except ImportError:
+    pass

--- a/lib/pymedphys/_dev/tests.py
+++ b/lib/pymedphys/_dev/tests.py
@@ -209,7 +209,7 @@ def run_cypress(args):
     if args.docker:
         commands = [
             "docker build . -t pymedphys",
-            "docker run -p 8501:8501 -e PORT=5000 pymedphys",
+            "docker run -p 8501:8501 -e PORT=8501 pymedphys",
             "yarn",
             "yarn cypress open",
         ]

--- a/lib/pymedphys/_dev/tests.py
+++ b/lib/pymedphys/_dev/tests.py
@@ -205,7 +205,19 @@ def run_pylint(_, remaining):
         os.chdir(original_cwd)
 
 
-def run_cypress(_):
-    cypress_test_utilities.run_test_commands_with_gui_process(
-        ["yarn", "yarn cypress open"]
-    )
+def run_cypress(args):
+    if args.docker:
+        commands = [
+            "docker build . -t pymedphys",
+            "docker run -p 8501:8501 -e PORT=5000 pymedphys",
+            "yarn",
+            "yarn cypress open",
+        ]
+
+        for command in commands:
+            subprocess.check_call(command, cwd=REPO_ROOT, shell=True)
+
+    else:
+        cypress_test_utilities.run_test_commands_with_gui_process(
+            ["yarn", "yarn cypress open"]
+        )

--- a/lib/pymedphys/_dev/tests.py
+++ b/lib/pymedphys/_dev/tests.py
@@ -208,6 +208,11 @@ def run_pylint(_, remaining):
 def run_cypress(args):
     if args.docker:
         try:
+            subprocess.check_call("docker stop pymedphys", shell=True)
+        except subprocess.CalledProcessError:
+            pass
+
+        try:
             subprocess.check_call("docker rm pymedphys", shell=True)
         except subprocess.CalledProcessError:
             pass

--- a/lib/pymedphys/cli/dev.py
+++ b/lib/pymedphys/cli/dev.py
@@ -61,6 +61,11 @@ def add_propagate_parser(dev_subparsers):
 
 def add_cypress_parser(dev_subparsers):
     parser = dev_subparsers.add_parser("cypress")
+    parser.add_argument(
+        "--docker",
+        help="Run cypress while pointing to the PyMedPhys docker testing docker image.",
+        action="store_true",
+    )
     parser.set_defaults(func=tests.run_cypress)
 
 


### PR DESCRIPTION
[EDIT]
After having Heroku use this docker image for a day it is not viable unfortunately. Just not enough RAM on the Heroku instance to run both MSSQL and Streamlit. I still would like to go down this docker route, but I suspect instead I might host the Streamlit app from a server at home.
[/EDIT]

---

So, I have created a docker container that boots both the PyMedPhys GUI and an MSSQL server. ~~This docker container (with 'Mosaiq' access) is now what is running on https://app.pymedphys.com.~~ [Now running it from home]

Of note however, now one can call `poetry run pymedphys dev cypress --docker` and this same docker image will build and boot on one's local machine (as long as docker is installed). That way, we can create Cypress tests that utilise a dummy Mosaiq database connection.

---

I suspect, the next PR will add something like `poetry run pymedphys dev tests --docker` flag to symbolise running all the normal pytest tests within the docker container.

---

To set up Heroku, I needed to make some settings changes over on the Heroku dashboard. This changed from a Python build to a Docker build. As such, so that all future Heroku builds weren't broken, I needed to force merge those PRs in. Those PRs are over at:

* https://github.com/pymedphys/pymedphys/pull/1477/files
* https://github.com/pymedphys/pymedphys/pull/1478/files
* https://github.com/pymedphys/pymedphys/pull/1479/files