### PR TITLE
[STACK trf -> base] Fix for TRF decoding

### DIFF
--- a/lib/pymedphys/_data/hashes.json
+++ b/lib/pymedphys/_data/hashes.json
@@ -89,6 +89,7 @@
   "tomo_mapcheck_test.txt": "93375b1b1a3eeee5f4810762545f42055f6b3b37",
   "tps_compare_dicom_files.zip": "d0d0a9676ae8ff8fca080611944fdafab5b6e83d",
   "treatment-record-anonymisation.zip": "274f3e84af33887645a12f4256b96d35f1380909",
+  "trf-references-and-baselines.zip": "3b674c937c2bd0fbbd673063676a3a4f85cb814f",
   "washed_out_bb.png": "06c7c32a1a4be6d2ebade915f28a998e3039c3a4",
   "water_phantom.zip": "b93ea8d89cf4030524ace0e67fa08082efd88776",
   "wlutz-demo-files.zip": "7d0fe2fb18924e566d0b70692e32ce186dc902fa",

--- a/lib/pymedphys/_data/hashes.json
+++ b/lib/pymedphys/_data/hashes.json
@@ -89,7 +89,6 @@
   "tomo_mapcheck_test.txt": "93375b1b1a3eeee5f4810762545f42055f6b3b37",
   "tps_compare_dicom_files.zip": "d0d0a9676ae8ff8fca080611944fdafab5b6e83d",
   "treatment-record-anonymisation.zip": "274f3e84af33887645a12f4256b96d35f1380909",
-  "trf-references-and-baselines.zip": "a64f37c2a07d561d5bc4d431377261016287f32a",
   "washed_out_bb.png": "06c7c32a1a4be6d2ebade915f28a998e3039c3a4",
   "water_phantom.zip": "b93ea8d89cf4030524ace0e67fa08082efd88776",
   "wlutz-demo-files.zip": "7d0fe2fb18924e566d0b70692e32ce186dc902fa",

--- a/lib/pymedphys/_data/urls.json
+++ b/lib/pymedphys/_data/urls.json
@@ -30,7 +30,7 @@
   "rtplan-anonymisation.zip": "https://zenodo.org/record/3930533/files/rtplan-anonymisation.zip?download=1",
   "treatment-record-anonymisation.zip": "https://zenodo.org/record/3931186/files/treatmentrecord-anonymisation.zip?download=1",
   "negative-metersetmap.trf": "https://zenodo.org/record/3973722/files/negative_mu_density.trf?download=1",
-  "trf-references-and-baselines.zip": "https://zenodo.org/record/4087961/files/trf-references-and-baselines.zip?download=1",
+  "trf-references-and-baselines.zip": "https://zenodo.org/record/4668177/files/trf-references-and-baselines.zip?download=1",
   "dicom-to-delivery-issue-#1047.zip": "https://github.com/pymedphys/pymedphys/files/5212087/NPCA_Anonymised.zip",
   "dicom-trf-pairs.zip": "https://zenodo.org/record/4255822/files/dicom_trf_pairs.zip?download=1",
   "previously_failing_iview_images.zip": "https://zenodo.org/record/4397768/files/previously_failing_iview_images.zip?download=1",

--- a/lib/pymedphys/_experimental/streamlit/apps/__init__.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/__init__.py
@@ -13,6 +13,7 @@ from . import (
     mosaiq_qcl_counter,
     sum_doses,
     transfer_check,
+    trf_explorer,
     weekly_check,
     wlutz,
 )

--- a/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pymedphys._imports import streamlit as st
-
 from pymedphys._streamlit import categories
 from pymedphys._streamlit.apps.metersetmap import _trf
 from pymedphys._streamlit.utilities import config as st_config

--- a/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
@@ -15,7 +15,7 @@
 from pymedphys._imports import streamlit as st
 
 from pymedphys._streamlit import categories
-from pymedphys._streamlit import utilities as _utilities
+from pymedphys._streamlit.apps.metersetmap import _trf
 from pymedphys._streamlit.utilities import config as st_config
 
 CATEGORY = categories.PLANNING
@@ -24,3 +24,5 @@ TITLE = "TRF Explorer"
 
 def main():
     config = st_config.get_config()
+
+    _trf.trf_input_method(config)

--- a/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/trf_explorer.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2021 Cancer Care Associates
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymedphys._imports import streamlit as st
+
+from pymedphys._streamlit import categories
+from pymedphys._streamlit import utilities as _utilities
+from pymedphys._streamlit.utilities import config as st_config
+
+CATEGORY = categories.PLANNING
+TITLE = "TRF Explorer"
+
+
+def main():
+    config = st_config.get_config()

--- a/lib/pymedphys/_trf/decode/config.json
+++ b/lib/pymedphys/_trf/decode/config.json
@@ -1,6 +1,7 @@
 {
     "time_increment": 0.04,
     "linac_state_codes": {
+        "34": "State Code Unknown",
         "39": "Move Only",
         "40": "Pause",
         "41": "Intersegment",

--- a/lib/pymedphys/_trf/decode/table.py
+++ b/lib/pymedphys/_trf/decode/table.py
@@ -75,6 +75,7 @@ def decode_rows(
     else:
         reference_state_codes = set(reference_state_code_keys)
 
+    non_reference_state_codes_found = set()
     decoded_results = []
     possible_column_adjustment_key = []
     for key, (line_grouping, linac_state_codes_column) in possible_groupings.items():
@@ -91,9 +92,22 @@ def decode_rows(
         if set(tentative_state_codes).issubset(reference_state_codes):
             decoded_results.append(decode_table_data(rows, line_grouping))
             possible_column_adjustment_key.append(key)
+        else:
+            non_reference_state_codes = set(tentative_state_codes).difference(
+                reference_state_codes
+            )
+            non_reference_state_codes_found = non_reference_state_codes_found.union(
+                non_reference_state_codes
+            )
 
     if not decoded_results:
-        raise ValueError("Decoded table didn't pass shape test")
+        raise ValueError(
+            "Decoded table didn't pass shape test. While attempting to "
+            "decode the TRF logfile there were some non-reference state "
+            "codes that were found. This may be the cause of this shape "
+            "test failure. The non-reference state codes found are "
+            f"{non_reference_state_codes_found}"
+        )
 
     if len(decoded_results) > 1:
         raise ValueError("Can't determine version of trf file from table shape")

--- a/lib/pymedphys/_trf/decode/trf2pandas.py
+++ b/lib/pymedphys/_trf/decode/trf2pandas.py
@@ -40,9 +40,7 @@ def trf2pandas(trf: path_or_binary_file) -> Tuple["pd.DataFrame", "pd.DataFrame"
             trf_contents = f.read()
 
     trf_header_contents, trf_table_contents = split_into_header_table(trf_contents)
-
     header_dataframe = header_as_dataframe(trf_header_contents)
-
     table_dataframe = decode_trf_table(trf_table_contents)
 
     return header_dataframe, table_dataframe


### PR DESCRIPTION
This here is an attempt to fix a set of issues which caused PyMedPhys to not be able to decode a range of TRF files. This issue was raised over at:

https://pymedphys.discourse.group/t/request-to-use-file-name-for-missing-field-id-and-field-name-in-trf/156?u=simonbiggs

But it has been an issue for quite a long time.