### PR TITLE
[STACK 1] Fix `Delivery.from_mosaiq`, remove db repeat

### DIFF
--- a/lib/pymedphys/_mosaiq/delivery.py
+++ b/lib/pymedphys/_mosaiq/delivery.py
@@ -333,13 +333,12 @@ class DeliveryMosaiq(DeliveryBase):
     @classmethod
     def from_mosaiq(cls, connection, field_id):
         total_mu, tx_field_points = delivery_data_sql(connection, field_id)
+        tx_field_points_index = tx_field_points["Index"].to_numpy(dtype=float)
 
-        cumulative_percentage_mu = tx_field_points["Index"].to_numpy(dtype=float)
-
-        if np.shape(cumulative_percentage_mu) == ():
+        if np.shape(tx_field_points_index) == ():
             mu_per_control_point = [0, total_mu]
         else:
-            cumulative_mu = cumulative_percentage_mu * total_mu / 100
+            cumulative_mu = tx_field_points_index / tx_field_points_index[-1] * total_mu
             mu_per_control_point = np.concatenate([[0], np.diff(cumulative_mu)])
 
         monitor_units = np.cumsum(mu_per_control_point).tolist()

--- a/lib/pymedphys/_mosaiq/delivery.py
+++ b/lib/pymedphys/_mosaiq/delivery.py
@@ -17,12 +17,11 @@
 """
 
 import functools
-import logging
 import struct
-from pprint import pformat
 
 from pymedphys._imports import attr
 from pymedphys._imports import numpy as np
+from pymedphys._imports import pandas as pd
 
 from pymedphys._base.delivery import DeliveryBase
 from pymedphys._utilities.transforms import convert_IEC_angle_to_bipolar
@@ -199,12 +198,15 @@ def append_x00_byte_to_all(raw_bytes_list):
 
 
 def check_all_items_equal_length(items, name):
-    all_lengths = [len(item) for item in items]
-    length = list(set(all_lengths))
+    all_lengths = {len(item) for item in items}
 
-    assert len(length) == 1, "All {} should be the same length".format(name)
+    if len(all_lengths) != 1:
+        raise ValueError(
+            f"All {name} should be the same length. The lengths seen were "
+            f"{all_lengths}."
+        )
 
-    return length[0]
+    return list(all_lengths)[0]
 
 
 def decode_msq_mlc(raw_bytes):
@@ -248,6 +250,44 @@ def collimation_to_bipolar_mm(mlc_a, mlc_b, coll_y1, coll_y2):
     return mlc, jaw
 
 
+def _raw_delivery_data_sql(connection, field_id):
+    txfield_results = api.execute(
+        connection,
+        """
+        SELECT
+            TxField.Meterset
+        FROM TxField
+        WHERE
+            TxField.FLD_ID = %(field_id)s
+        """,
+        {
+            "field_id": field_id,
+        },
+    )
+
+    txfieldpoint_results = api.execute(
+        connection,
+        """
+        SELECT
+            TxFieldPoint.[Index],
+            TxFieldPoint.A_Leaf_Set,
+            TxFieldPoint.B_Leaf_Set,
+            TxFieldPoint.Gantry_Ang,
+            TxFieldPoint.Coll_Ang,
+            TxFieldPoint.Coll_Y1,
+            TxFieldPoint.Coll_Y2
+        FROM TxFieldPoint
+        WHERE
+            TxFieldPoint.FLD_ID = %(field_id)s
+        ORDER BY
+            TxFieldPoint.Point
+        """,
+        {"field_id": field_id},
+    )
+
+    return txfield_results, txfieldpoint_results
+
+
 def delivery_data_sql(connection, field_id):
     """Get the treatment delivery data from Mosaiq given the SQL field_id
 
@@ -259,142 +299,42 @@ def delivery_data_sql(connection, field_id):
         txfield_results: The results from the TxField table.
         txfieldpoint_results: The results from the TxFieldPoint table.
     """
-    txfield_results = api.execute(
-        connection,
-        """
-        SELECT
-            TxField.Meterset,
-            TxField.RowVers
-        FROM TxField
-        WHERE
-            TxField.FLD_ID = %(field_id)s
-        """,
-        {
-            "field_id": field_id,
-        },
-    )
-    assert len(txfield_results) == 1
-    txfield_results[0] = txfield_results[0][0], struct.unpack(
-        "Q", txfield_results[0][1]
+    raw_txfield_results, raw_txfieldpoint_results = _raw_delivery_data_sql(
+        connection, field_id
     )
 
-    txfieldpoint_results = np.array(
-        api.execute(
-            connection,
-            """
-        SELECT
-            TxFieldPoint.[Index],
-            TxFieldPoint.A_Leaf_Set,
-            TxFieldPoint.B_Leaf_Set,
-            TxFieldPoint.Gantry_Ang,
-            TxFieldPoint.Coll_Ang,
-            TxFieldPoint.Coll_Y1,
-            TxFieldPoint.Coll_Y2,
-            TxFieldPoint.RowVers
-        FROM TxFieldPoint
-        WHERE
-            TxFieldPoint.FLD_ID = %(field_id)s
-        ORDER BY
-            TxFieldPoint.Point
-        """,
-            {"field_id": field_id},
+    if len(raw_txfield_results) != 1:
+        raise ValueError(
+            f"The return results from txfield query gave {raw_txfield_results}. "
+            "Expected exactly one row."
         )
+    meterset = np.array(raw_txfield_results[0]).astype(float)
+
+    if len(raw_txfieldpoint_results) == 0:
+        raise ValueError("No TxFieldPoints were returned.")
+
+    txfieldpoint_results = pd.DataFrame(
+        data=raw_txfieldpoint_results,
+        columns=[
+            "Index",
+            "A_Leaf_Set",
+            "B_Leaf_Set",
+            "Gantry_Ang",
+            "Coll_Ang",
+            "Coll_Y1",
+            "Coll_Y2",
+        ],
     )
-    assert len(txfieldpoint_results) >= 1
-    for one_point in txfieldpoint_results:
-        # convert to list, so we can change last element
-        one_point = list(one_point)
-        one_point[-1] = struct.unpack("Q", one_point[-1])
-        one_point = tuple(one_point)
 
-    return txfield_results, txfieldpoint_results
-
-
-def fetch_and_verify_mosaiq_sql(connection, field_id):
-    reference_txfield_results, reference_txfieldpoint_results = delivery_data_sql(
-        connection, field_id
-    )
-    test_txfield_results, test_txfieldpoint_results = delivery_data_sql(
-        connection, field_id
-    )
-
-    agreement = False
-
-    while not agreement:
-        agreements = [np.all(reference_txfield_results == test_txfield_results)]
-        for ref, test in zip(reference_txfieldpoint_results, test_txfieldpoint_results):
-            agreements.append(np.all(ref == test))
-
-        agreement = np.all(agreements)
-        if not agreement:
-            print("Mosaiq sql query gave conflicting data.")
-
-            # log mismatched values output
-            logger = logging.getLogger("mosaiq_delivery_data_sql")
-            logger.error("Mismatch of delivery_data_sql results:")
-
-            logger.error(pformat(reference_txfield_results))
-            logger.error(pformat(test_txfield_results))
-            logger.error(pformat(reference_txfieldpoint_results))
-            logger.error(pformat(test_txfieldpoint_results))
-
-            print("Trying again...")
-            reference_txfield_results = test_txfield_results
-            reference_txfieldpoint_results = test_txfieldpoint_results
-            test_txfield_results, test_txfieldpoint_results = delivery_data_sql(
-                connection, field_id
-            )
-
-    # return the txfield and point results, including rowversions
-    return test_txfield_results, test_txfieldpoint_results
+    return meterset, txfieldpoint_results
 
 
 class DeliveryMosaiq(DeliveryBase):
     @classmethod
     def from_mosaiq(cls, connection, field_id):
-        mosaiq_delivery_data = cls._from_mosaiq_base(connection, field_id)
-        reference_data = (
-            mosaiq_delivery_data.monitor_units,
-            mosaiq_delivery_data.mlc,
-            mosaiq_delivery_data.jaw,
-        )
+        total_mu, tx_field_points = delivery_data_sql(connection, field_id)
 
-        delivery_data = cls._from_mosaiq_base(connection, field_id)
-        test_data = (delivery_data.monitor_units, delivery_data.mlc, delivery_data.jaw)
-
-        agreement = False
-
-        while not agreement:
-            agreements = []
-            for ref, test in zip(reference_data, test_data):
-                agreements.append(np.all(ref == test))
-
-            agreement = np.all(agreements)
-            if not agreement:
-                print("Converted Mosaiq delivery data was conflicting.")
-                print(
-                    "MU agreement: {}\nMLC agreement: {}\n"
-                    "Jaw agreement: {}".format(*agreements)
-                )
-                print("Trying again...")
-                reference_data = test_data
-                delivery_data = cls._from_mosaiq_base(connection, field_id)
-                test_data = (
-                    delivery_data.monitor_units,
-                    delivery_data.mlc,
-                    delivery_data.jaw,
-                )
-
-        return delivery_data
-
-    @classmethod
-    def _from_mosaiq_base(cls, connection, field_id):
-        txfield_results, txfieldpoint_results = fetch_and_verify_mosaiq_sql(
-            connection, field_id
-        )
-
-        total_mu = np.array(txfield_results[0]).astype(float)
-        cumulative_percentage_mu = txfieldpoint_results[:, 0].astype(float)
+        cumulative_percentage_mu = tx_field_points["Index"].to_numpy(dtype=float)
 
         if np.shape(cumulative_percentage_mu) == ():
             mu_per_control_point = [0, total_mu]
@@ -404,14 +344,17 @@ class DeliveryMosaiq(DeliveryBase):
 
         monitor_units = np.cumsum(mu_per_control_point).tolist()
 
-        mlc_a = np.squeeze(decode_msq_mlc(txfieldpoint_results[:, 1].astype(bytes))).T
-        mlc_b = np.squeeze(decode_msq_mlc(txfieldpoint_results[:, 2].astype(bytes))).T
+        raw_mlc_a = tx_field_points["A_Leaf_Set"].to_numpy(dtype=bytes)
+        mlc_a = np.squeeze(decode_msq_mlc(raw_mlc_a)).T
 
-        msq_gantry_angle = txfieldpoint_results[:, 3].astype(float)
-        msq_collimator_angle = txfieldpoint_results[:, 4].astype(float)
+        raw_mlc_b = tx_field_points["B_Leaf_Set"].to_numpy(dtype=bytes)
+        mlc_b = np.squeeze(decode_msq_mlc(raw_mlc_b)).T
 
-        coll_y1 = txfieldpoint_results[:, 5].astype(float)
-        coll_y2 = txfieldpoint_results[:, 6].astype(float)
+        msq_gantry_angle = tx_field_points["Gantry_Ang"].to_numpy(dtype=float)
+        msq_collimator_angle = tx_field_points["Coll_Ang"].to_numpy(dtype=float)
+
+        coll_y1 = tx_field_points["Coll_Y1"].to_numpy(dtype=float)
+        coll_y2 = tx_field_points["Coll_Y2"].to_numpy(dtype=float)
 
         mlc, jaw = collimation_to_bipolar_mm(mlc_a, mlc_b, coll_y1, coll_y2)
         gantry = convert_IEC_angle_to_bipolar(msq_gantry_angle)

--- a/lib/pymedphys/tests/mosaiq/test_patient_name_fields.py
+++ b/lib/pymedphys/tests/mosaiq/test_patient_name_fields.py
@@ -81,22 +81,20 @@ def test_get_patient_fields(connection: pymedphys.mosaiq.Connection):
     assert len(fields_for_moe_df) == field_count
 
     # for each treatment field
-    for fld_id, txfield in fields_for_moe_df.iterrows():
-        print(fld_id, txfield)
+    for _, txfield in fields_for_moe_df.iterrows():
+        field_id = txfield["field_id"]
 
         # check that the field label matches the field name
         assert f"Field{txfield['field_label']}" == txfield["field_name"]
 
         # check for txfield control points
-        field_results, point_results = delivery.delivery_data_sql(
-            connection, txfield["field_id"]
-        )
+        total_mu, point_results = delivery.delivery_data_sql(connection, field_id)
 
-        assert field_results[0][0] == 100
+        assert total_mu == 100
         print(point_results)
 
         # iterate over the txfield results and see if they match
         current_index = 0.0
-        for tx_point in point_results:
+        for _, tx_point in point_results.iterrows():
             assert tx_point[0] >= current_index
             current_index = tx_point[0]


### PR DESCRIPTION
@dg1an3 here I removed that db-repeat that I was doing. I highly suspect it was because I hadn't undergone the ordering appropriately as you highlighted. It does align with the bug I was seeing. And, now we have a test to verify that it is appropriately and consistently pulling from MSSQL. I'd rather that test throw an error if it doesn't match baseline on first db query. So, I removed the retry loop. Thanks for helping me go through the process of pulling out that nasty thorn.