### PR TITLE
[STACK 1] Investigate plausibility of iso-cube based WLutz

### DIFF
--- a/lib/pymedphys/_experimental/streamlit/apps/__init__.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/__init__.py
@@ -7,6 +7,8 @@ from . import (
     electrons,
     extend_ct,
     icom,
+    iview_image_viewer,
+    iview_image_wlutz,
     iview_to_dicom,
     iviewdb,
     monaco_archive,

--- a/lib/pymedphys/_experimental/streamlit/apps/iview_image_viewer.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/iview_image_viewer.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2021 Cancer Care Associates
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pymedphys._imports import libjpeg, plt
+from pymedphys._imports import streamlit as st
+
+from pymedphys._streamlit import categories
+
+from pymedphys._experimental.wlutz import iview as _iview
+
+CATEGORY = categories.ALPHA
+TITLE = "iView Image Viewer"
+
+
+def main():
+    """A viewer for the back-end iView `.jpg` files.
+
+    The backend iView `.jpg` files are encoded in a format that is
+    rarely supported within modern software (1993 Lossless JPEG). 
+    As such, opening these
+    files using standard image software can be troublesome. This tool
+    was written to be able to readily view these files.
+    """
+    a_file = st.file_uploader("iView images 'jpg' file")
+
+    if a_file is None:
+        st.stop()
+
+    a_file.seek(0)
+    img_raw = libjpeg.decode(a_file.read())
+    x, y, image = _iview.iview_image_transform(img_raw)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(x, y, image)
+    ax.axis("equal")
+    st.pyplot(fig)
+
+    half_dimension = image.shape[0] // 2
+
+    zoom_selection = st.slider(
+        "Zoom in on central region",
+        min_value=1,
+        max_value=half_dimension,
+        value=half_dimension // 4,
+    )
+    zoom_slice = slice(half_dimension - zoom_selection, half_dimension + zoom_selection)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(x[zoom_slice], y[zoom_slice], image[zoom_slice, zoom_slice])
+    ax.axis("equal")
+    st.pyplot(fig)

--- a/lib/pymedphys/_experimental/streamlit/apps/iview_image_viewer.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/iview_image_viewer.py
@@ -28,7 +28,7 @@ def main():
     """A viewer for the back-end iView `.jpg` files.
 
     The backend iView `.jpg` files are encoded in a format that is
-    rarely supported within modern software (1993 Lossless JPEG). 
+    rarely supported within modern software (1993 Lossless JPEG).
     As such, opening these
     files using standard image software can be troublesome. This tool
     was written to be able to readily view these files.

--- a/lib/pymedphys/_experimental/streamlit/apps/iview_image_wlutz.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/iview_image_wlutz.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2021 Cancer Care Associates
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pymedphys._imports import libjpeg
+from pymedphys._imports import numpy as np
+from pymedphys._imports import streamlit as st
+
+from pymedphys._streamlit import categories
+
+from pymedphys._experimental.wlutz import iview as _iview
+from pymedphys._experimental.wlutz import main as _main
+from pymedphys._experimental.wlutz import reporting as _reporting
+
+CATEGORY = categories.ALPHA
+TITLE = "iView Image WLutz"
+
+
+def main():
+    """A tool for uploading individual iView backend image files and
+    undergoing ball-bearing and field edge detection.
+
+    Provides a facilities to tweak the back-end WLutz algorithm
+    to investigate the impact of these adjustments. This application
+    was originally written for the purpose of investigating the
+    plausibility of detecting an air-cavity instead of a ball-bearing
+    for utilising the WLutz algorithm for daily QA with the already
+    utilised during the morning kV image and couch movement tests.
+    """
+    a_file = st.file_uploader("iView images 'jpg' file")
+
+    ignore_errors = st.checkbox("Ignore errors", False)
+    zoom_factor = st.slider("Zoom factor", 1.0, 16.0, value=1.0)
+    bb_repeats = st.number_input(
+        "Number of repeat BB finding attempts", min_value=0, max_value=20, value=6
+    )
+    bb_consistency_tolerance = st.number_input(
+        "BB consistency tolerance (mm)", min_value=0.0, max_value=4.0, value=1.0
+    )
+
+    field_edge_x = st.number_input(
+        "Field edge x size (mm)", min_value=5.0, max_value=400.0, value=30.0
+    )
+    field_edge_y = st.number_input(
+        "Field edge y size (mm)", min_value=5.0, max_value=400.0, value=30.0
+    )
+
+    if a_file is None:
+        st.stop()
+
+    a_file.seek(0)
+    img_raw = libjpeg.decode(a_file.read())
+    x, y, image = _iview.iview_image_transform(img_raw)
+
+    vmin_default = float(np.min(image))
+    vmax_default = float(np.max(image))
+
+    vmin, vmax = st.slider(
+        "Colour range",
+        min_value=vmin_default,
+        max_value=vmax_default,
+        value=(vmin_default, vmax_default),
+    )
+
+    options = {
+        "bb_diameter": 12,
+        "edge_lengths": (field_edge_x, field_edge_y),
+        "penumbra": 2,
+    }
+
+    field_centre, bb_centre = _main.pymedphys_wlutz_calculate(
+        x,
+        y,
+        image,
+        fill_errors_with_nan=ignore_errors,
+        icom_field_rotation=0,
+        bb_repeats=bb_repeats,
+        bb_consistency_tol=bb_consistency_tolerance,
+        **options,
+    )
+
+    diff = field_centre - bb_centre
+    st.write(
+        f"""
+        ## Results
+
+        Field - BB (or air-gap) centre
+
+        * x deviation: `{diff[0]:.2f} mm`
+        * y deviation: `{diff[1]:.2f} mm`
+        """
+    )
+
+    fig, axs = _reporting.image_analysis_figure(
+        x,
+        y,
+        image,
+        bb_centre,
+        field_centre,
+        field_rotation=0,
+        vmin=vmin,
+        vmax=vmax,
+        **options,
+    )
+
+    ylim = np.array(axs[0, 0].get_ylim())
+    xlim = np.array(axs[0, 0].get_xlim())
+
+    axs[0, 0].set_ylim(ylim / zoom_factor)
+    axs[0, 0].set_xlim(xlim / zoom_factor)
+
+    st.pyplot(fig)

--- a/lib/pymedphys/_experimental/streamlit/utilities/iview/ui.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/iview/ui.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import pathlib
 from typing import List, Union, cast
 
 from typing_extensions import Literal
@@ -42,23 +42,24 @@ def iview_and_icom_filter_and_align(
     (
         database_directory,
         icom_directory,
-        qa_directory,
         database_table,
         selected_date,
-        selected_machine_id,
+        linac_to_directories_map,
     ) = _utilities.get_directories_and_initial_database(config, refresh_cache)
 
     icom_patients_directory = icom_directory.joinpath("patients")
 
     database_table = _get_user_image_set_selection(database_table, advanced_mode)
-    # if advanced_mode:
-    #     st.write(database_table)
-
     database_table = _load_image_frame_database(
         database_directory, database_table, refresh_cache, advanced_mode
     )
-    # if advanced_mode:
-    #     st.write(database_table)
+
+    machine_ids = database_table["machine_id"].unique()
+    if len(machine_ids) != 1:
+        raise ValueError("Expected exactly one machine id")
+
+    selected_machine_id = machine_ids[0]
+    qa_directory = pathlib.Path(linac_to_directories_map[selected_machine_id]["qa"])
 
     filepaths_to_load, offset_to_apply = _sync.icom_iview_timestamp_alignment(
         database_table,

--- a/lib/pymedphys/_experimental/wlutz/reporting.py
+++ b/lib/pymedphys/_experimental/wlutz/reporting.py
@@ -21,9 +21,9 @@ from . import createaxis, imginterp, transformation
 
 
 def image_analysis_figure(
-    x: "np.array",
-    y: "np.array",
-    img: "np.array",
+    x: "np.ndarray",
+    y: "np.ndarray",
+    img: "np.ndarray",
     bb_centre: Tuple[float, float],
     field_centre: Tuple[float, float],
     field_rotation: float,
@@ -31,6 +31,8 @@ def image_analysis_figure(
     edge_lengths: Tuple[float, float],
     penumbra: float,
     units="(mm)",
+    vmin=None,
+    vmax=None,
 ):
     """Create a figure which displays diagnostic information for the WLutz result.
 
@@ -59,6 +61,12 @@ def image_analysis_figure(
         edge penumbra.
     units : str, optional
         The units string to display on the figure, by default "(mm)".
+    vmin : float, optional
+        A value to bound the colourmap on the lower end. Defaults to
+        None which is internally adjusted to be the minimum of ``img``.
+    vmax : float, optional
+        A value to bound the colourmap on the upper end. Defaults to
+        None which is internally adjusted to be the maximum of ``img``.
 
     Returns
     -------
@@ -118,6 +126,8 @@ def image_analysis_figure(
         y_bb_interp,
         pixel_value_label,
         units=units,
+        vmin=vmin,
+        vmax=vmax,
     )
 
     profile_flip_plot(axs[2, 0], x_axis, field(*x_field_interp))
@@ -188,6 +198,8 @@ def image_with_overlays(
     y_bb_interp,
     pixel_value_label,
     units="(mm)",
+    vmin=None,
+    vmax=None,
 ):
     rect_crosshair_dx = [
         -edge_lengths[0] / 2,
@@ -200,7 +212,7 @@ def image_with_overlays(
     rect_dx = [-edge_lengths[0] / 2, 0, edge_lengths[0], 0, -edge_lengths[0]]
     rect_dy = [-edge_lengths[1] / 2, edge_lengths[1], 0, -edge_lengths[1], 0]
 
-    c = ax.pcolormesh(x, y, img, shading="nearest")
+    c = ax.pcolormesh(x, y, img, shading="nearest", vmin=vmin, vmax=vmax)
     fig.colorbar(c, ax=ax, label=pixel_value_label)
 
     ax.plot(*draw_by_diff(rect_dx, rect_dy, field_transform), "k", lw=3)

--- a/lib/pymedphys/_experimental/wlutz/types.py
+++ b/lib/pymedphys/_experimental/wlutz/types.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 Cancer Care Associates
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple, Union
+
+from pymedphys._imports import numpy as np  # pylint: disable = unused-import
+
+TwoNumbers = Union[Tuple[float, float], "np.ndarray"]

--- a/lib/pymedphys/_streamlit/index.py
+++ b/lib/pymedphys/_streamlit/index.py
@@ -15,6 +15,7 @@
 import functools
 import pathlib
 import re
+import textwrap
 import time
 
 from pymedphys._imports import streamlit as st
@@ -134,6 +135,12 @@ def main():
 
     if session_state.app != "index":
         st.title(application_options[session_state.app].TITLE)
+
+        docstring = application_options[session_state.app].main.__doc__
+        if docstring is not None:
+            docstring = textwrap.dedent(f"    {docstring}")
+            st.write(docstring)
+
         if st.sidebar.button("Return to Index"):
             swap_app("index")
 

--- a/lib/pymedphys/tests/experimental/wlutz/test_bb.py
+++ b/lib/pymedphys/tests/experimental/wlutz/test_bb.py
@@ -87,10 +87,7 @@ def run_test(
         bb_max_attenuation,
     )
 
-    (
-        determined_field_centre,
-        determined_bb_centre,
-    ) = _wlutz._pymedphys_wlutz_calculate(  # pylint: disable = protected-access
+    (determined_field_centre, determined_bb_centre,) = _wlutz.pymedphys_wlutz_calculate(
         x,
         y,
         img,

--- a/lib/pymedphys/tests/experimental/wlutz/test_field_finding.py
+++ b/lib/pymedphys/tests/experimental/wlutz/test_field_finding.py
@@ -36,7 +36,7 @@ def test_find_field_in_image():
     image_path = pymedphys.data_path("wlutz_image.png")
     x, y, img = iview.iview_image_transform_from_path(image_path)
 
-    centre, _ = _wlutz._pymedphys_wlutz_calculate(  # pylint: disable = protected-access
+    centre, _ = _wlutz.pymedphys_wlutz_calculate(
         x, y, img, np.nan, edge_lengths, 2, expected_rotation
     )
 


### PR DESCRIPTION
Project goal
------------

Make it so that WLutz can run every morning utilising the "warm-up" beams of the Linac. The workflow adjustment means that morning warm-up + daily QA doesn't actually take any longer, but every day, for every gantry angle, for every beam the field centre to kv based couch shift location deviation is being recorded.

Timeline
--------

Enough time so that I am not making any commits during my last week (last two weeks?) of work. I finish up on the 18/5.

This PR
-------

Creates tools to readily investigate how the WLutz algorithm needs to be adjusted to detect an air cavity within the daily kV QA cube instead of a BB.

The below zip contains three images extracted from an arc delivered to this cube, one from each of our clinical energies (6 MV, 10 MV, and 6 MV FFF):

> [img.zip](https://github.com/pymedphys/pymedphys/files/6354850/img.zip)

By running `poetry run pymedphys gui` within this branch and then going to the new iView Image WLutz app (<http://localhost:8501/?app=iview-image-wlutz>), the `.jpg` files within the above zip can be dragged and dropped into the app to observe the algorithm in action.

Up Next
-------

Implement an option within the current WLutz Arc tool to utilise these algorithm adjustments.