### PR TITLE
Ignore hung test on Windows for now

### DIFF
--- a/lib/pymedphys/tests/icom/test_icom_cli.py
+++ b/lib/pymedphys/tests/icom/test_icom_cli.py
@@ -21,10 +21,15 @@ import subprocess
 import sys
 import tempfile
 
+import pytest
+
 from pymedphys._data import download
 from pymedphys._root import LIBRARY_ROOT
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Does not currently work on Windows"
+)
 def test_icom_cli():
     icom_server_process = multiprocessing.Process(target=_mock_icom_server)
     icom_server_process.start()


### PR DESCRIPTION
Ideally this fix would get to the bottom of why `pymedphys` can't be found on the path when running this test on Windows. But for now this fix is sufficient as this is already being testing on Linux.

When doing more work on the binary I'll need to remove this ignore.