### PR TITLE
forced save to dcm standard

### DIFF
--- a/lib/pymedphys/_experimental/pinnacle/image.py
+++ b/lib/pymedphys/_experimental/pinnacle/image.py
@@ -226,5 +226,5 @@ def convert_image(image, export_path):
             export_path, f"{image.image['Modality']}.{imageds.SOPInstanceUID}.dcm"
         )
 
-        imageds.save_as(output_file)
+        imageds.save_as(output_file, False)
         image.logger.info("Exported: %s to %s", file, output_file)

--- a/lib/pymedphys/_experimental/pinnacle/image.py
+++ b/lib/pymedphys/_experimental/pinnacle/image.py
@@ -226,5 +226,5 @@ def convert_image(image, export_path):
             export_path, f"{image.image['Modality']}.{imageds.SOPInstanceUID}.dcm"
         )
 
-        imageds.save_as(output_file, False)
+        imageds.save_as(output_file, write_like_original=False)
         image.logger.info("Exported: %s to %s", file, output_file)

--- a/lib/pymedphys/_experimental/pinnacle/rtplan.py
+++ b/lib/pymedphys/_experimental/pinnacle/rtplan.py
@@ -997,4 +997,4 @@ def convert_plan(plan, export_path):
     # Save the RTPlan Dicom File
     output_file = os.path.join(export_path, RPfilename)
     plan.logger.info("Creating Plan file: %s", output_file)
-    ds.save_as(output_file)
+    ds.save_as(output_file, False)

--- a/lib/pymedphys/_experimental/pinnacle/rtplan.py
+++ b/lib/pymedphys/_experimental/pinnacle/rtplan.py
@@ -997,4 +997,4 @@ def convert_plan(plan, export_path):
     # Save the RTPlan Dicom File
     output_file = os.path.join(export_path, RPfilename)
     plan.logger.info("Creating Plan file: %s", output_file)
-    ds.save_as(output_file, False)
+    ds.save_as(output_file, write_like_original=False)

--- a/lib/pymedphys/_experimental/pinnacle/rtstruct.py
+++ b/lib/pymedphys/_experimental/pinnacle/rtstruct.py
@@ -534,4 +534,4 @@ def convert_struct(plan, export_path):
     # Save the RTDose Dicom File
     output_file = os.path.join(export_path, struct_filename)
     plan.logger.info("Creating Struct file: %s", output_file)
-    ds.save_as(output_file)
+    ds.save_as(output_file, False)

--- a/lib/pymedphys/_experimental/pinnacle/rtstruct.py
+++ b/lib/pymedphys/_experimental/pinnacle/rtstruct.py
@@ -534,4 +534,4 @@ def convert_struct(plan, export_path):
     # Save the RTDose Dicom File
     output_file = os.path.join(export_path, struct_filename)
     plan.logger.info("Creating Struct file: %s", output_file)
-    ds.save_as(output_file, False)
+    ds.save_as(output_file, write_like_original=False)


### PR DESCRIPTION
This forces the pinnacle converter to save every result file according to dicom standards instead of the previous attempt to maintain the source file version. This produced errors as pinnacle source files are often binary and structure sets/plan files should be ASCII