### PR TITLE
Gamma speed up: more realistic calculations

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -374,8 +374,6 @@ jobs:
 
           git status
           git diff-index --quiet HEAD --
-          REPO1: ${{ github.event.pull_request.head.repo.full_name }}
-          REPO2: ${{ github.event.pull_request.base.repo.full_name }}
 
       ## Pyright
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -374,6 +374,8 @@ jobs:
 
           git status
           git diff-index --quiet HEAD --
+          REPO1: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO2: ${{ github.event.pull_request.base.repo.full_name }}
 
       ## Pyright
 

--- a/lib/pymedphys/docs/users/howto/gamma/speed-up.ipynb
+++ b/lib/pymedphys/docs/users/howto/gamma/speed-up.ipynb
@@ -339,16 +339,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -379,7 +369,7 @@
    "source": [
     "Let's see how these parameters affect the gamma calculation time.\n",
     "\n",
-    "For simplicity, we restrict ourself on the z-slice with the highest disagreement.\n",
+    "For simplicity, we restrict ourself on the 10 z-slices above and below the z-slice with highest disagreement.\n",
     "\n",
     "We also add a small shift to the evaluation dose distribution to obtain a worse gamma agreement which will make the computation slower:"
    ]
@@ -390,17 +380,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# add 1% of the evaluation dose standard deviation where the evaluation dose in non zero\n",
+    "# add 7.8% of the evaluation dose standard deviation where the evaluation dose in non zero\n",
+    "# the value was chosen to obtain a gamma pass rate = 90.9%\n",
     "dose_evaluation_Z = np.where(\n",
-    "    dose_evaluation[z_max_diff] != 0,\n",
-    "    dose_evaluation[z_max_diff] + .1 * np.std(dose_evaluation[z_max_diff]),\n",
-    "    dose_evaluation[z_max_diff]\n",
+    "    dose_evaluation[z_start:z_end] != 0,\n",
+    "    dose_evaluation[z_start:z_end] + .078 * np.std(dose_evaluation[z_start:z_end]),\n",
+    "    dose_evaluation[z_start:z_end]\n",
     ")\n",
-    "dose_reference_Z = np.array(dose_reference[z_max_diff])\n",
+    "dose_reference_Z = np.array(dose_reference[z_start:z_end])\n",
     "\n",
-    "# keep only the y, x axes\n",
-    "axes_reference_subset = axes_reference[1:]\n",
-    "axes_evaluation_subset = axes_evaluation[1:]"
+    "# keep only 10 slices for the z axis\n",
+    "axes_reference_subset = axes_reference[0][z_start:z_end], axes_reference[1], axes_reference[2]\n",
+    "axes_evaluation_subset = axes_evaluation[0][z_start:z_end], axes_evaluation[1], axes_evaluation[2]"
    ]
   },
   {
@@ -433,7 +424,7 @@
     "    axes_evaluation_subset, dose_evaluation_Z, \n",
     "    dose_percent_threshold, distance_mm_threshold,\n",
     "    lower_percent_dose_cutoff=1 # 1% lower threshold\n",
-    "    )"
+    ")"
    ]
   },
   {
@@ -456,7 +447,7 @@
    "source": [
     "If we want to evaluate the gamma pass rate, we are uninterested in accurate gamma index values for $\\gamma > 1$.\n",
     "\n",
-    "We can suppress calculations of gamma values above 1 by passing a suitable value (e.g., 1.1) to the <code>max_gamma</code> parameter of the PyMedPhys [gamma](https://docs.pymedphys.com/users/ref/lib/gamma.html) function"
+    "We can suppress calculations of gamma values above 1 by passing a suitable value (e.g., 1.01) to the <code>max_gamma</code> parameter of the PyMedPhys [gamma](https://docs.pymedphys.com/users/ref/lib/gamma.html) function"
    ]
   },
   {
@@ -472,7 +463,7 @@
     "    axes_evaluation_subset, dose_evaluation_Z, \n",
     "    dose_percent_threshold, distance_mm_threshold,\n",
     "    lower_percent_dose_cutoff=1, # 1% lower threshold\n",
-    "    max_gamma=1.1 # stop when gamma > 1.1\n",
+    "    max_gamma=1.01 # stop when gamma > 1.01\n",
     "    )"
    ]
   },
@@ -484,7 +475,8 @@
    "source": [
     "valid_gamma = gamma[~np.isnan(gamma)]\n",
     "\n",
-    "out = plt.hist(valid_gamma, bins=20, density=True)\n",
+    "# increased number of bins to highlight points above 1\n",
+    "out = plt.hist(valid_gamma, bins=101, density=True)\n",
     "plt.xlabel(\"gamma index\")\n",
     "plt.ylabel(\"probability density\")\n",
     "title = plt.title(f\"Gamma passing rate: {np.sum(valid_gamma <= 1) / len(valid_gamma) * 100:.1f}%\")"
@@ -494,7 +486,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice how the gamma passing rate value (shown in the plot title) did not change. Of course now all the points with $\\gamma > 1.1$ are collapsed to the 1.1 bin."
+    "Notice how the gamma passing rate value (shown in the plot title) did not change. Of course, all the points with $\\gamma > 1.01$ are collapsed to the $[1.00, 1.01]$ bin."
    ]
   },
   {
@@ -520,14 +512,14 @@
     "    dose_percent_threshold, distance_mm_threshold,\n",
     "    lower_percent_dose_cutoff=1,\n",
     "    random_subset=int(len(dose_reference_Z.flat) // 10) # sample only 1/10 of the grid points\n",
-    "    )"
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The $\\gamma$ index distribution should look something like the following plot"
+    "As you can see, the computation time is almost halved. The $\\gamma$ index distribution should look something like the following plot"
    ]
   },
   {
@@ -548,7 +540,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, the computation time decreased and, despite the the PyMedPhys [gamma](https://docs.pymedphys.com/users/ref/lib/gamma.html) function sampled one 10th of the points, the pass rate deviates by less than 1% from the true value. Therefore, you can use <code>random_subset</code> to get a sense of what could be the pass rate of the dose distributions you are assessing."
+    "Despite the PyMedPhys [gamma](https://docs.pymedphys.com/users/ref/lib/gamma.html) function sampled only one 10th of the points, the pass rate deviates by less than 1% from the true value. Therefore, you can use <code>random_subset</code> to get a sense of what could be the pass rate of the dose distributions you are assessing."
    ]
   },
   {
@@ -565,9 +557,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pymedphys",
    "language": "python",
-   "name": "python3"
+   "name": "pymedphys"
   },
   "language_info": {
    "codemirror_mode": {
@@ -579,10 +571,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.7.8"
   },
   "nbsphinx": {
    "timeout": 600
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ae94be08af574f9c02d1caee21912b44743f275ccdadc1a58580d7205420e742"
+   }
   }
  },
  "nbformat": 4,

--- a/lib/pymedphys/docs/users/howto/gamma/speed-up.ipynb
+++ b/lib/pymedphys/docs/users/howto/gamma/speed-up.ipynb
@@ -389,7 +389,7 @@
     ")\n",
     "dose_reference_Z = np.array(dose_reference[z_start:z_end])\n",
     "\n",
-    "# keep only 10 slices for the z axis\n",
+    "# keep only 10 slices along the z axis\n",
     "axes_reference_subset = axes_reference[0][z_start:z_end], axes_reference[1], axes_reference[2]\n",
     "axes_evaluation_subset = axes_evaluation[0][z_start:z_end], axes_evaluation[1], axes_evaluation[2]"
    ]
@@ -557,9 +557,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pymedphys",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "pymedphys"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -571,15 +571,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.10.4"
   },
   "nbsphinx": {
    "timeout": 600
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ae94be08af574f9c02d1caee21912b44743f275ccdadc1a58580d7205420e742"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As noted in #1686, the gamma speed up how-to can be improved with more realistic computations.

Now, the examples show calculations on (small) 3D dose distributions with a pass rate of 90.9%.

On my workstation, I obtained the following computation times (all with `lower_percent_dose_cutoff=1`):

- Using the default gamma params: 12min 4s
- Using `max_gamma=1.01`: 11min 48s
- Using `random_subset` to sample 1/10th of the points: 6min 20s

I think that now the "aggressive" choice of sampling 1/10th of the points is acceptable when compared to the time gain.