### PR TITLE
Restore electron factor API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -118,6 +118,7 @@
     "decubitus",
     "dedupe",
     "deduplication",
+    "deformability",
     "deidentified",
     "deps",
     "deque",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -104,6 +104,7 @@
     "customisation",
     "Customise",
     "customising",
+    "cutout",
     "cython",
     "dataelem",
     "dataset",

--- a/lib/pymedphys/__init__.py
+++ b/lib/pymedphys/__init__.py
@@ -1,6 +1,6 @@
 """Module docstring."""
 
-from . import dicom, metersetmap, mosaiq, mudensity, trf
+from . import dicom, electronfactors, metersetmap, mosaiq, mudensity, trf
 from ._data import data_path, zenodo_data_paths, zip_data_paths
 from ._delivery import Delivery
 from ._gamma.implementation.shell import gamma_shell as gamma

--- a/lib/pymedphys/_electronfactors/__init__.py
+++ b/lib/pymedphys/_electronfactors/__init__.py
@@ -17,7 +17,7 @@ from .core import (
     calculate_percent_prediction_differences,
     convert2_ratio_perim_area,
     create_transformed_mesh,
-    parameterise_insert,
+    parametrise_insert,
     spline_model,
     spline_model_with_deformability,
     visual_alignment_of_equivalent_ellipse,

--- a/lib/pymedphys/_electronfactors/core.py
+++ b/lib/pymedphys/_electronfactors/core.py
@@ -372,7 +372,7 @@ def calculate_length(x, y, width):
     return length
 
 
-def parameterise_insert(x, y, callback=None):
+def parametrise_insert(x, y, callback=None):
     """Return the parameterisation of an insert given x and y coords."""
     circle_centre = search_for_centre_of_largest_bounded_circle(x, y, callback=callback)
     width = calculate_width(x, y, circle_centre)
@@ -430,7 +430,7 @@ def parameterise_insert_with_visual_alignment(
     complete_parameterisation_callback=None,
 ):
     """Return an equivalent ellipse with visual alignment parameters."""
-    width, length, circle_centre = parameterise_insert(x, y, callback=circle_callback)
+    width, length, circle_centre = parametrise_insert(x, y, callback=circle_callback)
     if complete_parameterisation_callback is not None:
         complete_parameterisation_callback(width, length, circle_centre)
     x_shift, y_shift, rotation_angle = visual_alignment_of_equivalent_ellipse(

--- a/lib/pymedphys/_experimental/streamlit/apps/electrons.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/electrons.py
@@ -136,7 +136,7 @@ def _per_reference_index(config, tel_contents, reference_index):
     x = insert_coords[0::2] / 10
     y = insert_coords[1::2] / 10
 
-    width, length, circle_centre = electronfactors.parameterise_insert(x, y)
+    width, length, circle_centre = electronfactors.parametrise_insert(x, y)
 
     left, right = st.columns(2)
 

--- a/lib/pymedphys/docs/users/ref/lib/electronfactors.rst
+++ b/lib/pymedphys/docs/users/ref/lib/electronfactors.rst
@@ -1,0 +1,28 @@
+#######################
+Electron Cutout Factors
+#######################
+
+*******
+Summary
+*******
+
+.. automodule:: pymedphys.electronfactors
+    :no-members:
+
+
+
+***
+API
+***
+
+.. autofunction:: pymedphys.electronfactors.parameterise_insert
+
+.. autofunction:: pymedphys.electronfactors.spline_model
+
+.. autofunction:: pymedphys.electronfactors.calculate_deformability
+
+.. autofunction:: pymedphys.electronfactors.spline_model_with_deformability
+
+.. autofunction:: pymedphys.electronfactors.calculate_percent_prediction_differences
+
+.. autofunction:: pymedphys.electronfactors.visual_alignment_of_equivalent_ellipse

--- a/lib/pymedphys/docs/users/ref/lib/index.rst
+++ b/lib/pymedphys/docs/users/ref/lib/index.rst
@@ -13,5 +13,6 @@ itself. Below is the documentation for a range of these libraries.
     gamma
     mosaiq
     metersetmap
+    trf
     electronfactors
     experimental/index

--- a/lib/pymedphys/docs/users/ref/lib/index.rst
+++ b/lib/pymedphys/docs/users/ref/lib/index.rst
@@ -13,5 +13,5 @@ itself. Below is the documentation for a range of these libraries.
     gamma
     mosaiq
     metersetmap
-    trf
+    electronfactors
     experimental/index

--- a/lib/pymedphys/electronfactors.py
+++ b/lib/pymedphys/electronfactors.py
@@ -1,5 +1,5 @@
 """A suite of functions that model electron insert/cutout factors by
-parameterising them as equivalent ellipses.
+parametrising them as equivalent ellipses.
 """
 
 # pylint: disable = unused-import

--- a/lib/pymedphys/electronfactors.py
+++ b/lib/pymedphys/electronfactors.py
@@ -1,0 +1,17 @@
+"""A suite of functions that model electron insert/cutout factors by
+parameterising them as equivalent ellipses.
+"""
+
+# pylint: disable = unused-import
+
+from ._electronfactors import (
+    calculate_deformability,
+    calculate_percent_prediction_differences,
+    convert2_ratio_perim_area,
+    create_transformed_mesh,
+    parametrise_insert,
+    plot_model,
+    spline_model,
+    spline_model_with_deformability,
+    visual_alignment_of_equivalent_ellipse,
+)


### PR DESCRIPTION
When this API was removed it was assumed it wasn't in use apart from one clinic. But then, in the months following a validation paper came out:

https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8598145/

Given the API was in use, it is going to be re-exposed mostly as it was (with one API spelling error correction).

---

As an aside, this is an example where we should be collecting de-identified usage stats so that we can make informed maintenance decisions -- https://github.com/pymedphys/pymedphys/issues/1651#issuecomment-1140601707