### PR TITLE
update version to point to pre-release of next minor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pymedphys"
-version = "0.39.1"
+version = "0.40.0-dev0"
 readme = "README.rst"
 description = "Medical Physics library"
 authors = [
@@ -89,8 +89,8 @@ scikit-image = { version = ">=0.18.1", optional = true } # groups = ["user", "al
 
 # Utilising the pymedphys fork of pylibjpeg-libjpeg to fix the following issue:
 # https://github.com/pymedphys/pymedphys/issues/1556#issuecomment-1152821285
-pymedphys-pylibjpeg-libjpeg = { version = "1.3.1", optional = true } # groups = ["user", "all"]
-# pylibjpeg-libjpeg = { version = "*", optional = true } # groups = ["user", "all"]
+# pymedphys-pylibjpeg-libjpeg = { version = "1.3.1", optional = true } # groups = ["user", "all"]
+pylibjpeg-libjpeg = { version = ">=1.3.2", optional = true } # groups = ["user", "all"]
 
 
 # PyLinac is pinned due to historical algorithm changes with both minor and


### PR DESCRIPTION
change reference from pymedphys specific libjpeg to common/pydicom pylibjpeg-libjpeg package, and specify minimum version of 1.3.2