### PR TITLE
Bring back quickcheck

### DIFF
--- a/lib/pymedphys/_experimental/quickcheck/__init__.py
+++ b/lib/pymedphys/_experimental/quickcheck/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Rafael Ayala
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .quickcheck_cli import export_cli

--- a/lib/pymedphys/_experimental/quickcheck/qcheck.py
+++ b/lib/pymedphys/_experimental/quickcheck/qcheck.py
@@ -1,0 +1,232 @@
+# Copyright (C) 2022 Rafael Ayala
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import codecs
+import datetime
+import re
+import socket
+
+from pymedphys._imports import numpy as np
+from pymedphys._imports import pandas as pd
+from pymedphys._imports import tqdm
+
+
+class QuickCheck:
+    """A class to interact with PTW QuickCheck linac daily QA device.
+    Common usage will look like:
+        from pymedphys.experimental import QuickCheck
+        qc = QuickCheck('QUICKCHECK-XXX')      QUICKCHECK-XXX (your QUICKCHECK device hostname or IP)
+        qc.connect()
+        qc.get_measurements()
+
+            Receiving Quickcheck measurements
+            100%|██████████| 108/108 [00:01<00:00, 58.57it/s]
+
+        qc.measurements.to_csv(csv_path)       csv_path to save data as csv file
+
+    ...
+
+    Attributes
+    ----------
+    ip : str
+        IP address or hostname of the device
+    MSG : str
+        Instruction to be sent to QuickCheck device e.g. MEASCNT, KEY, SER...
+    measurements: pandas DataFrame
+        DataFrame that contains all measurements retrieved from QuickCheck
+    data: str
+        Processed received data string
+
+    """
+
+    def __init__(self, ip):
+        self.ip = ip
+        self.port = 8123
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # UDP
+        self.sock.settimeout(3)
+        self.MSG = b""
+        self.raw_MSG = ""
+        self.measurements = pd.DataFrame()
+        self.data = ""
+        self.raw_data = b""
+        self.connected = False
+
+    def connect(self):
+        """Opens connection to the device and prints its serial number if successful"""
+        print("UDP target IP:", self.ip)
+        print("UDP target port:", self.port)
+        self.send_quickcheck("SER")
+        if "SER" in self.data:
+            self.connected = True
+            print("Connected to Quickcheck")
+            print(self.data)
+
+    def close(self):
+        """Closes connection to the device"""
+        self.sock.close()
+        del self.sock
+        self.connected = False
+
+    def _prepare_qcheck(self):
+        """Appends characters \r\n to MSG"""
+        self.MSG = (
+            self.raw_MSG.encode()
+            + codecs.decode("0d", "hex")
+            + codecs.decode("0a", "hex")
+        )
+
+    def _socket_send(self):
+        """Encapsulates socket sending of MSG and data reception, easier to mock in tests"""
+        self.data = ""
+        self.sock.sendto(self.MSG, (self.ip, self.port))
+        self.raw_data, _ = self.sock.recvfrom(4096)
+
+    def send_quickcheck(self, message):
+        """Sends instructions to device
+
+        Args:
+            message: str
+                Instruction to send to QuickCheck device. eg: SER, KEY, MEASCNT, MEASGET;INDEX-MEAS=xx
+
+        """
+        self.raw_MSG = message
+        self._prepare_qcheck()
+        max_retries = 3
+        n_retry = 0
+
+        while True:
+            try:
+                self._socket_send()
+                data = self.raw_data.decode(encoding="utf-8")
+                self.data = data.strip("\r\n")
+                break
+            except socket.timeout:
+                if n_retry == max_retries:
+                    print(
+                        """
+                          Connection Error  - Reached max retries
+                          Quickcheck device unreachable, please check your settings"""
+                    )
+                    self.data = ""
+                    break
+
+                print("Connection Timeout")
+                n_retry += 1
+                print("Retrying connection {}/{}".format(n_retry, max_retries))
+
+    def _parse_measurements(self):
+        """Parses received data based on sent MSG"""
+        data_split = self.data.split(";")
+        m = {}  # Dictionary with measurements
+        if data_split[0] == "MEASGET":
+            #  MD section:__________________________________________________________
+            MD = re.findall(r"MD=\[(.*?)\]", self.data)[0]
+            m["MD_ID"] = np.int(re.findall(r"ID=(.*?);", MD)[0])
+            meas_date = re.findall(r"Date=(.*?);", MD)[0]
+            m["MD_Date"] = datetime.datetime.strptime(meas_date, "%Y-%m-%d").date()
+            meas_time = re.findall(r"Time=(.*?)$", MD)[0]
+            m["MD_Time"] = datetime.datetime.strptime(meas_time, "%H:%M:%S").time()
+            m["MD_DateTime"] = datetime.datetime.combine(m["MD_Date"], m["MD_Time"])
+            #  MV section:__________________________________________________________
+            str_val = re.findall(r"MV=\[(.*?)\]", self.data)[0]
+            regex_map = {
+                "MV_CAX": "CAX=(.*?);",
+                "MV_G10": "G10=(.*?);",
+                "MV_L10": "L10=(.*?);",
+                "MV_T10": "T10=(.*?);",
+                "MV_R10": "R10=(.*?);",
+                "MV_G20": "G20=(.*?);",
+                "MV_L20": "L20=(.*?);",
+                "MV_T20": "T20=(.*?);",
+                "MV_R20": "R20=(.*?);",
+                "MV_E1": "E1=(.*?);",
+                "MV_E2": "E2=(.*?);",
+                "MV_E3": "E3=(.*?);",
+                "MV_E4": "E4=(.*?);",
+                "MV_Temp": "Temp=(.*?);",
+                "MV_Press": "Press=(.*?);",
+                "MV_CAXRate": "CAXRate=(.*?);",
+                "MV_ExpTime": "ExpTime=(.*?)$",
+            }
+            for key, pattern in regex_map.items():
+                m[key] = np.float(re.findall(pattern, str_val)[0])
+
+            #  AV section:__________________________________________________________
+            AV = re.findall(r"AV=\[(.*?)\]\]", self.data)[0]
+            AV = AV + "]"  # add last character ]
+            for s in ("CAX", "FLAT", "SYMGT", "SYMLR", "BQF", "We"):
+                str_val = re.findall(s + r"=\[(.*?)\]", AV)[0]
+                m["AV_" + s + "_Min"] = np.float(re.findall("Min=(.*?);", str_val)[0])
+                m["AV_" + s + "_Max"] = np.float(re.findall("Max=(.*?);", str_val)[0])
+                m["AV_" + s + "_Target"] = np.float(
+                    re.findall("Target=(.*?);", str_val)[0]
+                )
+                m["AV_" + s + "_Norm"] = np.float(re.findall("Norm=(.*?);", str_val)[0])
+                m["AV_" + s + "_Value"] = np.float(
+                    re.findall("Value=(.*?);", str_val)[0]
+                )
+                m["AV_" + s + "_Valid"] = np.int(re.findall("Valid=(.*?)$", str_val)[0])
+
+            #  WORK section:__________________________________________________________
+            str_val = re.findall(r"WORK=\[(.*?)\]", self.data)[0]
+
+            m["WORK_ID"] = np.int(re.findall("ID=(.*?);", str_val)[0])
+            m["WORK_Name"] = re.findall("Name=(.*?)$", str_val)[0]
+
+            #  TASK section:__________________________________________________________
+            str_val = re.findall(r"TASK=\[(.*?)\];MV", self.data)[0]
+            m["TASK_ID"] = np.int(re.findall(r"ID=(.*?);", str_val)[0])
+            m["TASK_TUnit"] = re.findall(r"TUnit=(.*?);", str_val)[0]
+            m["TASK_En"] = np.int(re.findall(r"En=(.*?);", str_val)[0])
+            m["TASK_Mod"] = re.findall(r"Mod=(.*?);", str_val)[0]
+            m["TASK_Fs"] = re.findall(r"Fs=(.*?);", str_val)[0]
+            m["TASK_SSD"] = np.int(re.findall(r"SDD=(.*?);", str_val)[0])
+            m["TASK_Ga"] = np.int(re.findall(r"Ga=(.*?);", str_val)[0])
+            m["TASK_We"] = np.int(re.findall(r"We=(.*?);", str_val)[0])
+            m["TASK_MU"] = np.int(re.findall(r"MU=(.*?);", str_val)[0])
+            m["TASK_My"] = np.float(re.findall(r"My=(.*?);", str_val)[0])
+            m["TASK_Info"] = re.findall(r"Info=(.*?)$", str_val)[0]
+
+            str_val = re.findall(r"Prot=\[(.*?)\];", str_val)[0]
+            m["TASK_Prot_Name"] = re.findall(r"Name=(.*?);", str_val)[0]
+            m["TASK_Prot_Flat"] = np.int(re.findall(r"Flat=(.*?);", str_val)[0])
+            m["TASK_Prot_Sym"] = np.int(re.findall(r"Sym=(.*?)$", str_val)[0])
+        elif data_split[0] == "MEASCNT":
+            m[data_split[0]] = np.int(data_split[1:][0])
+        elif data_split[0] in ("PTW", "SER", "KEY"):
+            m[data_split[0]] = data_split[1:]
+        return m
+
+    def get_measurements(self):
+        """Retrieves all the measurements in the QuickCheck device and stores them in self.measurements"""
+        if not self.connected:
+            raise ValueError("Quickcheck device not connected")
+        self.send_quickcheck("MEASCNT")
+        if "MEASCNT" not in self.data:
+            self.send_quickcheck("MEASCNT")
+        m = self._parse_measurements()
+        if "MEASCNT" in m:
+            n_meas = m["MEASCNT"]
+            print("Receiving Quickcheck measurements")
+            meas_list = []
+            for m in tqdm.tqdm(range(n_meas)):
+                control = False
+                while not control:
+                    self.send_quickcheck("MEASGET;INDEX-MEAS=" + "%d" % (m,))
+                    control = self.raw_MSG in self.data
+
+                meas = self._parse_measurements()
+                meas_list.append(meas)
+            self.measurements = pd.DataFrame(meas_list)

--- a/lib/pymedphys/_experimental/quickcheck/quickcheck_cli.py
+++ b/lib/pymedphys/_experimental/quickcheck/quickcheck_cli.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 Rafael Ayala
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+from .qcheck import QuickCheck
+
+
+def export_cli(args):
+    """
+    expose a cli to allow export of Quickcheck data to csv
+    """
+
+    ip = args.ip
+    csv_path = args.csv_path
+    # Create a logger to std out for cli
+    log_level = logging.INFO
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
+
+    ch = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    ch.setFormatter(formatter)
+    ch.setLevel(log_level)
+    logger.addHandler(ch)
+
+    qc = QuickCheck(ip)
+    qc.connect()
+    if qc.connected:
+        qc.get_measurements()
+        print(" Saving data to " + csv_path)
+        qc.close()
+        qc.measurements.to_csv(csv_path)

--- a/lib/pymedphys/experimental/__init__.py
+++ b/lib/pymedphys/experimental/__init__.py
@@ -2,4 +2,4 @@
 
 from pymedphys._experimental.cube import align_cube_to_structure, cubify
 
-from . import fileformats, pinnacle, pseudonymisation
+from . import fileformats, pinnacle, pseudonymisation, quickcheck

--- a/lib/pymedphys/experimental/quickcheck.py
+++ b/lib/pymedphys/experimental/quickcheck.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Rafael Ayala
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable = unused-import
+from pymedphys._experimental.quickcheck.qcheck import QuickCheck

--- a/lib/pymedphys/tests/experimental/quickcheck/test_quickcheck.py
+++ b/lib/pymedphys/tests/experimental/quickcheck/test_quickcheck.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2022 Rafael Ayala
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable = unused-import
+
+from unittest import TestCase, mock
+
+from pymedphys.experimental.quickcheck import QuickCheck
+
+
+def mock_socket_send(qc):
+    """Function that mocks a PTW QuickCheck device"""
+    message = qc.MSG
+    if message == b"SER\r\n":
+        qc.raw_data = b"SER;1000\r\n"
+    elif message == b"MEASCNT\r\n":
+        qc.raw_data = b"MEASCNT;3\r\n"
+    elif message.startswith(b"MEASGET;INDEX-MEAS="):
+        index = message.split(b"=")[1].decode()
+        raw_string = (
+            "MEASGET;INDEX-MEAS={};MD=[ID=1636992223;Date=2021-11-15;Time=16:03:43];WORK=["
+            "ID=1628265817;Name=VERSA BETA];TASK=[ID=188165042;TUnit=VERSA BETA;Prot=["
+            "Name=HGUGM;Flat=2;Sym=1];Mod=Photons;En=6;Fs=200x200;SDD=1000;Ga=0;We=0;MU=100;My=1.0000E+00"
+            ";Info=QA DIARIO: 6 MV];MV=["
+            "CAX=1.0572E+00;G10=1.0894E+00;L10=1.0869E+00;T10=1.0874E+00;R10=1.0846E+00;G20=1.0990E+00;L20=1"
+            ".0884E+00;T20=1.0965E+00;R20=1.0923E+00;E1=9.9593E-01;E2=1.0490E+00;E3=1.0794E+00;E4=1.1317E+00"
+            ";Temp=2.3590E+01;Press=9.3290E+02;CAXRate=5.4921E+00;ExpTime=1.1550E+01];AV=[CAX=["
+            "Min=9.7500E+01;Max=1.0250E+02;Target=1.0000E+02;Norm=9.5371E+01;Value=1.0083E+02;Valid=1];FLAT="
+            "[Min=9.7000E+01;Max=1.0300E+02;Target=1.0000E+02;Norm=9.5919E+01;Value=9.9709E+01;Valid=1];"
+            "SYMGT=[Min=9.7000E+01;Max=1.0300E+02;Target=1.0000E+02;Norm=9.9028E-01;Value=9.9253E+01;Valid=1"
+            "];SYMLR=[Min=9.7000E+01;Max=1.0300E+02;Target=1.0000E+02;Norm=9.9062E-01;Value=9.9423E+01;Valid"
+            "=1];BQF=[Min=9.5000E+01;Max=1.0500E+02;Target=1.0000E+02;Norm=1.6314E+01;Value=1.0059E+02;Valid"
+            "=1];We=[Min=0.0000E+00;Max=0.0000E+00;Target=0.0000E+00;Norm=1.0000E+00;Value=0.0000E+00;"
+            "Valid=1]];3229717283\r\n".format(index)
+        )
+        qc.raw_data = raw_string.encode()
+
+
+@mock.patch.object(QuickCheck, "_socket_send", autospec=True)
+class TestQcMethods(TestCase):
+    def test_connect(self, _socket_send):
+        """Tests connection to QuickCheck device, asserts connection, serial number in data and disconnection"""
+        qc = QuickCheck("127.0.0.1")
+        _socket_send.side_effect = mock_socket_send
+        qc.connect()
+        self.assertTrue(qc.connected)
+        self.assertEqual("SER;1000", qc.data)
+        qc.close()
+        self.assertFalse(qc.connected)
+
+    def test_get_measurements(self, socket_send):
+        """Tests measurements retrieval, checks shape of the measurements pandas dataframe and specific
+        values of the data"""
+        qc = QuickCheck("127.0.0.1")
+        socket_send.side_effect = mock_socket_send
+        qc.connect()
+        qc.get_measurements()
+        qc.close()
+        self.assertEqual((3, 73), qc.measurements.shape)
+        self.assertEqual(6, qc.measurements.iloc[0]["TASK_En"])
+        self.assertEqual(100.83, qc.measurements.iloc[1]["AV_CAX_Value"])
+        self.assertEqual("VERSA BETA", qc.measurements.iloc[2]["WORK_Name"])
+
+    def test_not_connected(self, socket_send):
+        """Tests that ValueError is raised when attempting to retrieve measurements without calling connect() before"""
+        qc = QuickCheck("127.0.0.1")
+        socket_send.side_effect = mock_socket_send
+        self.assertFalse(qc.connected)
+        with self.assertRaises(ValueError):
+            qc.get_measurements()
+        qc.close()


### PR DESCRIPTION
Thanks @ayalalazaro for the this (https://github.com/pymedphys/pymedphys/issues/1794#issuecomment-1519638796)

Here is a PR pulling the code back in.

The commands run to bring back quickcheck were:

```
git checkout 3e45a8510ec3d4d20195c5c5447d0618e2d0d7b4 -- lib/pymedphys/_experimental/quickcheck
git checkout 3e45a8510ec3d4d20195c5c5447d0618e2d0d7b4 -- lib/pymedphys/tests/experimental/quickcheck
git checkout 3e45a8510ec3d4d20195c5c5447d0618e2d0d7b4 -- lib/pymedphys/experimental/__init__.py
git checkout 3e45a8510ec3d4d20195c5c5447d0618e2d0d7b4 -- lib/pymedphys/experimental/quickcheck.py
```

Please let me know if I missed anything :slightly_smiling_face: 

---

To run the tests for quickcheck I did the following:

```
poetry run pymedphys dev tests -k quickcheck
```

Which got the following output:

```
Running pytest with cwd set to:
    /home/simon/git/pymedphys/lib/pymedphys

Test session starts (platform: linux, Python 3.11.3, pytest 7.3.1, pytest-sugar 0.9.7)
rootdir: /home/simon/git/pymedphys/lib/pymedphys
plugins: sugar-0.9.7, hypothesis-5.49.0, rerunfailures-11.1.2
collected 163 items / 160 deselected / 3 selected                                                                                                                        

 tests/experimental/quickcheck/test_quickcheck.py ✓                                                                                                         33% ███▍      

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― TestQcMethods.test_get_measurements ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

self = <pymedphys.tests.experimental.quickcheck.test_quickcheck.TestQcMethods testMethod=test_get_measurements>, socket_send = <function _socket_send at 0x7f32bde5a480>

    def test_get_measurements(self, socket_send):
        """Tests measurements retrieval, checks shape of the measurements pandas dataframe and specific
        values of the data"""
        qc = QuickCheck("127.0.0.1")
        socket_send.side_effect = mock_socket_send
        qc.connect()
>       qc.get_measurements()

tests/experimental/quickcheck/test_quickcheck.py:68: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_experimental/quickcheck/qcheck.py:219: in get_measurements
    m = self._parse_measurements()
_experimental/quickcheck/qcheck.py:207: in _parse_measurements
    m[data_split[0]] = np.int(data_split[1:][0])
_vendor/apipkg/__init__.py:238: in __getattribute__
    return getattr(getmod(), name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

attr = 'int'

    def __getattr__(attr):
        # Warn for expired attributes, and return a dummy function
        # that always raises an exception.
        import warnings
        try:
            msg = __expired_functions__[attr]
        except KeyError:
            pass
        else:
            warnings.warn(msg, DeprecationWarning, stacklevel=2)
    
            def _expired(*args, **kwds):
                raise RuntimeError(msg)
    
            return _expired
    
        # Emit warnings for deprecated attributes
        try:
            val, msg = __deprecated_attrs__[attr]
        except KeyError:
            pass
        else:
            warnings.warn(msg, DeprecationWarning, stacklevel=2)
            return val
    
        if attr in __future_scalars__:
            # And future warnings for those that will change, but also give
            # the AttributeError
            warnings.warn(
                f"In the future `np.{attr}` will be defined as the "
                "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    
        if attr in __former_attrs__:
>           raise AttributeError(__former_attrs__[attr])
E           AttributeError: module 'numpy' has no attribute 'int'.
E           `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

/home/simon/.cache/pypoetry/virtualenvs/pymedphys-OJ9w3Q6B-py3.11/lib/python3.11/site-packages/numpy/__init__.py:305: AttributeError
-------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------
UDP target IP: 127.0.0.1
UDP target port: 8123
Connected to Quickcheck
SER;1000

 tests/experimental/quickcheck/test_quickcheck.py ⨯✓                                                                                                       100% ██████████
======================================================================== short test summary info =========================================================================
FAILED tests/experimental/quickcheck/test_quickcheck.py::TestQcMethods::test_get_measurements - AttributeError: module 'numpy' has no attribute 'int'.

Results (1.97s):
       2 passed
       1 failed
         - tests/experimental/quickcheck/test_quickcheck.py:62 TestQcMethods.test_get_measurements
     160 deselected

```
