### PR TITLE
Add the linac state code 16, correct the meanning of code 34

### DIFF
--- a/lib/pymedphys/_trf/decode/config.json
+++ b/lib/pymedphys/_trf/decode/config.json
@@ -1,8 +1,8 @@
 {
     "time_increment": 0.04,
     "linac_state_codes": {
-        "16": "Closed State",
-        "34": "Preparatory",
+        "16": "Closed",
+        "34": "State Code Unknown",
         "39": "Move Only",
         "40": "Pause",
         "41": "Intersegment",

--- a/lib/pymedphys/_trf/decode/config.json
+++ b/lib/pymedphys/_trf/decode/config.json
@@ -1,7 +1,8 @@
 {
     "time_increment": 0.04,
     "linac_state_codes": {
-        "34": "State Code Unknown",
+        "16": "Closed State",
+        "34": "Preparatory",
         "39": "Move Only",
         "40": "Pause",
         "41": "Intersegment",


### PR DESCRIPTION
I  add the linac state code 16, and correct the meanning of code 34 in the "pymedphys/lib/pymedphys/_trf/decode/config.json". Please review it. Thank you!
The meanning of codes 16  and 34 were given in the following figure, which was obtained from Elekta linac engineer.
<img width="275" alt="状态编码1" src="https://github.com/pymedphys/pymedphys/assets/152958108/bf5886e4-ca89-4289-815c-16d4d914828f">
