### PR TITLE
Fix the icom listener test error

### DIFF
--- a/lib/pymedphys/tests/icom/test_icom_cli.py
+++ b/lib/pymedphys/tests/icom/test_icom_cli.py
@@ -19,6 +19,7 @@ import pathlib
 import socket
 import subprocess
 import sys
+import time
 import tempfile
 
 import pytest
@@ -45,6 +46,8 @@ def test_icom_cli():
             ["pymedphys", "icom", "listen", "127.0.0.1", temp_dir], env=env
         )
         icom_server_process.join()
+        # leave some time for the icom listener to parse data stream and create txt files after the socket is closed 
+        time.sleep(1)
         icom_listen_cli.terminate()
 
         live_files = list(pathlib.Path(temp_dir).glob("**/*.txt"))

--- a/lib/pymedphys/tests/icom/test_icom_cli.py
+++ b/lib/pymedphys/tests/icom/test_icom_cli.py
@@ -34,8 +34,9 @@ from pymedphys._root import LIBRARY_ROOT
 )
 def test_icom_cli():
     data = download_files()
-    icom_server_process = multiprocessing.Process(target=_mock_icom_server,
-                                                  args=(data,))
+    icom_server_process = multiprocessing.Process(
+        target=_mock_icom_server, args=(data,)
+    )
     icom_server_process.start()
 
     env = os.environ.copy()
@@ -62,7 +63,6 @@ def download_files():
     def load_icom_stream(icom_path):
         with lzma.open(icom_path, "r") as f:
             contents = f.read()
-
         return contents
 
     data = load_icom_stream(icom_paths[0])


### PR DESCRIPTION
with regards to the failing test_icom_cli, it looks like the test icom listener is being terminated immediately after the data has finished sending from the mock icom server, which means there is not enough time for the byte stream to be saved to txt files and stored in a temp directory. An easy slightly ugly fix, but i think robust enough is to put a time.sleep(1) between icom_server_process.join() and icom_listen_cli.terminate() 