### PR TITLE
Fix some streamlit issues

### DIFF
--- a/lib/pymedphys/_experimental/streamlit/apps/electrons.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/electrons.py
@@ -74,7 +74,7 @@ def _set_parameters():
     return demo_mode
 
 
-@st.cache
+@st.cache_data
 def _download_demo_data():
     cwd = pathlib.Path.cwd()
     pymedphys.zip_data_paths("metersetmap-gui-e2e-data.zip", extract_directory=cwd)
@@ -82,7 +82,7 @@ def _download_demo_data():
     return cwd.joinpath("pymedphys-gui-demo")
 
 
-@st.cache
+@st.cache_data
 def _get_config(demo_mode):
     if demo_mode:
         path = _download_demo_data()

--- a/lib/pymedphys/_experimental/streamlit/apps/iviewdb.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/iviewdb.py
@@ -29,7 +29,7 @@ CATEGORY = categories.PLANNING
 TITLE = "iView Database Explorer"
 
 
-@st.cache()
+@st.cache_data()
 def get_files_for_extension(directory: pathlib.Path, extension: str):
     """Cached file list.
 

--- a/lib/pymedphys/_experimental/streamlit/apps/mosaiq_to_csv.py
+++ b/lib/pymedphys/_experimental/streamlit/apps/mosaiq_to_csv.py
@@ -266,7 +266,7 @@ def _append_filtered_table(connection, df, table, column_name, column_value):
     return df
 
 
-@st.cache(ttl=86400, hash_funcs={pymedphys.mosaiq.Connection: id})
+@st.cache_data(ttl=86400, hash_funcs={pymedphys.mosaiq.Connection: id})
 def _get_all_columns(connection, table):
     """Get the column schema from an MSSQL table."""
     raw_columns = pymedphys.mosaiq.execute(
@@ -287,7 +287,7 @@ def _get_all_columns(connection, table):
     return columns, types
 
 
-@st.cache(ttl=86400, hash_funcs={pymedphys.mosaiq.Connection: id})
+@st.cache_data(ttl=86400, hash_funcs={pymedphys.mosaiq.Connection: id})
 def _get_filtered_table(connection, table, column_name, column_value):
     """Get the rows from an MSSQL table where the column_value matches
     within the given column_name."""

--- a/lib/pymedphys/_experimental/streamlit/utilities/dbf.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/dbf.py
@@ -2,7 +2,7 @@ from pymedphys._imports import dbfread
 from pymedphys._imports import streamlit as st
 
 
-@st.cache()
+@st.cache_data()
 def get_dbf_table(path):
     try:
         return dbfread.DBF(path)

--- a/lib/pymedphys/_experimental/streamlit/utilities/icom.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/icom.py
@@ -127,7 +127,7 @@ def _get_file_datetimes(icom_paths):
     return timestamps
 
 
-@st.cache(show_spinner=False, suppress_st_warning=True)
+@st.cache_data(show_spinner=False)
 def _get_relevant_times(filepath):
     icom_datetime, meterset, machine_id = get_icom_datetimes_meterset_machine(filepath)
 
@@ -154,7 +154,7 @@ def _get_relevant_times(filepath):
     return machine_id, pd.Series(relevant_times, name="datetime")
 
 
-@st.cache(show_spinner=False)
+@st.cache_data(show_spinner=False)
 def get_icom_datetimes_meterset_machine(filepath):
     icom_stream = read_icom_log(filepath)
 
@@ -194,7 +194,7 @@ def _adjust_icom_datetime_to_remove_duplicates(icom_datetime):
 
 # TODO: Remove "allow_output_mutation" once determine what is causing
 # the issue here.
-@st.cache(show_spinner=False, allow_output_mutation=True)
+@st.cache_data(show_spinner=False)
 def get_icom_dataset(filepath):
     icom_stream = read_icom_log(filepath)
     icom_data_points = pmp_icom_extract.get_data_points(icom_stream)

--- a/lib/pymedphys/_experimental/streamlit/utilities/iview/_dbf.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/iview/_dbf.py
@@ -224,7 +224,7 @@ def _dbf_to_pandas_without_cache(path: pathlib.Path) -> "pd.DataFrame":
     return pd.DataFrame(iter(dbf.get_dbf_table(path)))
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data()
 def _dbf_to_pandas_with_cache(path: pathlib.Path) -> "List[pd.DataFrame]":
     """Streamlit cached dbf read.
 

--- a/lib/pymedphys/_experimental/streamlit/utilities/iview/_frames.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/iview/_frames.py
@@ -198,7 +198,7 @@ def xml_frame_based_database(
     return _final_frame_column_adjustment(merged)
 
 
-@st.cache()
+@st.cache_data()
 def _calc_filepath_from_frames_dbid(dbid_series):
     return [f"img/{f'{dbid:0>8x}'.upper()}.jpg" for dbid in dbid_series]
 
@@ -232,7 +232,7 @@ def _final_frame_column_adjustment(table):
     ]
 
 
-@st.cache()
+@st.cache_data()
 def _load_xml(filepath):
     with open(filepath) as fd:
         doc = xmltodict.parse(fd.read())
@@ -240,7 +240,7 @@ def _load_xml(filepath):
     return doc
 
 
-@st.cache()
+@st.cache_data()
 def _data_from_doc(doc):
     table_rows = []
 
@@ -270,7 +270,7 @@ def _data_from_doc(doc):
     return table_rows
 
 
-@st.cache()
+@st.cache_data()
 def _calc_xml_filepaths(table):
     return (
         "patient_"
@@ -281,7 +281,7 @@ def _calc_xml_filepaths(table):
     )
 
 
-@st.cache()
+@st.cache_data()
 def _calc_xml_based_jpg_filepaths(table):
     return (
         "patient_"

--- a/lib/pymedphys/_experimental/streamlit/utilities/iview/_sync.py
+++ b/lib/pymedphys/_experimental/streamlit/utilities/iview/_sync.py
@@ -263,7 +263,7 @@ def _get_time_diffs(iview_datetimes, icom_datetimes):
     return alignment_time_diffs
 
 
-@st.cache
+@st.cache_data
 def _estimated_initial_deviation_to_apply(iview_datetimes, icom_datetimes):
     alignment_time_diffs = _get_time_diffs(iview_datetimes, icom_datetimes)
 
@@ -273,7 +273,7 @@ def _estimated_initial_deviation_to_apply(iview_datetimes, icom_datetimes):
     return datetime.timedelta(seconds=deviation_to_apply)
 
 
-@st.cache
+@st.cache_data
 def _determine_basinhopping_offset(iview_datetimes, icom_datetimes):
     initial_deviation_to_apply = _estimated_initial_deviation_to_apply(
         iview_datetimes, icom_datetimes
@@ -295,7 +295,7 @@ def _determine_basinhopping_offset(iview_datetimes, icom_datetimes):
     return basinhopping_offset, basinhopping_minimise_f
 
 
-@st.cache
+@st.cache_data
 def _determine_loop_offset(iview_datetimes, icom_datetimes):
     to_minimise = _create_icom_timestamp_minimiser(iview_datetimes, icom_datetimes)
     total_offset = datetime.timedelta(seconds=0)

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_config.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_config.py
@@ -31,7 +31,7 @@ def config_in_current_directory():
     return HERE
 
 
-@st.cache
+@st.cache_data
 def download_demo_files():
     cwd = pathlib.Path.cwd()
     pymedphys.zip_data_paths("metersetmap-gui-e2e-data.zip", extract_directory=cwd)
@@ -52,7 +52,7 @@ def get_config(config_mode):
     return st_config.get_config(path)
 
 
-@st.cache
+@st.cache_data
 def get_dicom_export_locations(config):
     site_directories = st_config.get_site_directories(config)
     dicom_export_locations = {
@@ -63,7 +63,7 @@ def get_dicom_export_locations(config):
     return dicom_export_locations
 
 
-@st.cache
+@st.cache_data
 def get_icom_live_stream_directories(config):
     icom_live_stream_directories = {}
     for site in config["site"]:
@@ -76,7 +76,7 @@ def get_icom_live_stream_directories(config):
     return icom_live_stream_directories
 
 
-@st.cache
+@st.cache_data
 def get_machine_centre_map(config):
     machine_centre_map = {}
     for site in config["site"]:
@@ -100,7 +100,7 @@ def _get_alias_with_fallback(site_mosaiq_config):
     return f"{site_mosaiq_config['hostname']}:{port}"
 
 
-@st.cache
+@st.cache_data
 def get_mosaiq_details(config):
     mosaiq_details = {
         site["name"]: {
@@ -117,28 +117,28 @@ def get_mosaiq_details(config):
     return mosaiq_details
 
 
-@st.cache
+@st.cache_data
 def get_default_icom_directories(config):
     default_icom_directory = config["icom"]["patient_directories"]
 
     return default_icom_directory
 
 
-@st.cache
+@st.cache_data
 def get_default_gamma_options(config):
     default_gamma_options = config["gamma"]
 
     return default_gamma_options
 
 
-@st.cache
+@st.cache_data
 def get_logfile_root_dir(config):
     logfile_root_dir = pathlib.Path(config["trf_logfiles"]["root_directory"])
 
     return logfile_root_dir
 
 
-@st.cache
+@st.cache_data
 def get_indexed_backups_directory(config):
     logfile_root_dir = get_logfile_root_dir(config)
     indexed_backups_directory = logfile_root_dir.joinpath("diagnostics/already_indexed")
@@ -146,7 +146,7 @@ def get_indexed_backups_directory(config):
     return indexed_backups_directory
 
 
-@st.cache
+@st.cache_data
 def get_indexed_trf_directory(config):
     logfile_root_dir = get_logfile_root_dir(config)
     indexed_trf_directory = logfile_root_dir.joinpath("indexed")

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_deliveries.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_deliveries.py
@@ -18,24 +18,24 @@ from pymedphys._imports import streamlit as st
 import pymedphys
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data()
 def delivery_from_trf(pandas_table):
     return pymedphys.Delivery._from_pandas(  # pylint: disable = protected-access
         pandas_table
     )
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data()
 def delivery_from_icom(icom_stream):
     return pymedphys.Delivery.from_icom(icom_stream)
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data()
 def delivery_from_tel(tel_path):
     return pymedphys.Delivery.from_monaco(tel_path)
 
 
-@st.cache(hash_funcs={pymedphys.mosaiq.Connection: id}, allow_output_mutation=True)
+@st.cache_data(hash_funcs={pymedphys.mosaiq.Connection: id})
 def delivery_from_mosaiq(connection_and_field_id):
     connection, field_id = connection_and_field_id
     return pymedphys.Delivery.from_mosaiq(connection, field_id)

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_dicom.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_dicom.py
@@ -27,7 +27,7 @@ def pydicom_hash_function(dicom):
     return hash(dicom.SOPInstanceUID)
 
 
-@st.cache(hash_funcs={pydicom.dataset.FileDataset: pydicom_hash_function})
+@st.cache_data(hash_funcs={pydicom.dataset.FileDataset: pydicom_hash_function})
 def load_dicom_file_if_plan(filepath):
     dcm = pydicom.read_file(str(filepath), force=True, stop_before_pixels=True)
     if dcm.SOPClassUID == DICOM_PLAN_UID:

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_icom.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_icom.py
@@ -24,7 +24,7 @@ from pymedphys._streamlit.utilities import exceptions as _exceptions
 from pymedphys._utilities import patient as utl_patient
 
 
-@st.cache
+@st.cache_data
 def load_icom_stream(icom_path):
     with lzma.open(icom_path, "r") as f:
         contents = f.read()

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_mosaiq.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_mosaiq.py
@@ -22,12 +22,12 @@ from pymedphys._streamlit.utilities import misc as st_misc
 from pymedphys._streamlit.utilities import mosaiq as st_mosaiq
 
 
-@st.cache(hash_funcs={pymedphys.mosaiq.Connection: id})
+@st.cache_data(hash_funcs={pymedphys.mosaiq.Connection: id})
 def get_patient_fields(connection, patient_id):
     return msq_helpers.get_patient_fields(connection, patient_id)
 
 
-@st.cache(hash_funcs={pymedphys.mosaiq.Connection: id})
+@st.cache_data(hash_funcs={pymedphys.mosaiq.Connection: id})
 def get_patient_name(connection, patient_id):
     return msq_helpers.get_patient_name(connection, patient_id)
 

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_trf.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_trf.py
@@ -27,7 +27,7 @@ from pymedphys._trf.manage import index as pmp_index
 from pymedphys._utilities import patient as utl_patient
 
 
-@st.cache
+@st.cache_data
 def _get_mosaiq_configuration(config, headers):
     machine_centre_map = _config.get_machine_centre_map(config)
     mosaiq_details = _config.get_mosaiq_details(config)
@@ -280,7 +280,7 @@ def trf_input_method(config, patient_id="", key_namespace="", **_):
     }
 
 
-@st.cache()
+@st.cache_data()
 def _read_trf(path_or_binary):
     try:
         path_or_binary.seek(0)

--- a/lib/pymedphys/_streamlit/apps/metersetmap/_trf.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/_trf.py
@@ -296,6 +296,6 @@ def _read_trf(path_or_binary):
     header = _header.decode_header(trf_header_contents)
     header_dataframe = pd.DataFrame([header], columns=_header.Header._fields)
 
-    table_dataframe = _table.decode_trf_table(trf_table_contents, header)
+    table_dataframe = _table.decode_trf_table(trf_table_contents, header_dataframe)
 
     return header_dataframe, table_dataframe

--- a/lib/pymedphys/_streamlit/apps/metersetmap/main.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/main.py
@@ -249,21 +249,33 @@ def plot_and_save_results(
 
     diff = evaluation_metersetmap - reference_metersetmap
 
-    imageio.imwrite(
-        reference_filepath,
-        st_misc.normalize_and_convert_to_uint8(reference_metersetmap),
-    )
-    imageio.imwrite(
-        evaluation_filepath,
-        st_misc.normalize_and_convert_to_uint8(evaluation_metersetmap),
-    )
-    imageio.imwrite(diff_filepath, st_misc.normalize_and_convert_to_uint8(diff))
-    imageio.imwrite(gamma_filepath, st_misc.normalize_and_convert_to_uint8(gamma))
-
     largest_metersetmap = np.max(
         [np.max(evaluation_metersetmap), np.max(reference_metersetmap)]
     )
     largest_diff = np.max(np.abs(diff))
+
+    imageio.imwrite(
+        reference_filepath,
+        st_misc.normalize_and_convert_to_uint8(
+            reference_metersetmap, vmin=0, vmax=largest_metersetmap
+        ),
+    )
+    imageio.imwrite(
+        evaluation_filepath,
+        st_misc.normalize_and_convert_to_uint8(
+            evaluation_metersetmap, vmin=0, vmax=largest_metersetmap
+        ),
+    )
+    imageio.imwrite(
+        diff_filepath,
+        st_misc.normalize_and_convert_to_uint8(
+            diff, vmin=-largest_diff, vmax=largest_diff
+        ),
+    )
+    imageio.imwrite(
+        gamma_filepath,
+        st_misc.normalize_and_convert_to_uint8(gamma, vmin=0, vmax=2),
+    )
 
     widths = [1, 1]
     heights = [0.5, 1, 1, 1, 0.4]

--- a/lib/pymedphys/_streamlit/apps/metersetmap/main.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/main.py
@@ -249,10 +249,16 @@ def plot_and_save_results(
 
     diff = evaluation_metersetmap - reference_metersetmap
 
-    imageio.imwrite(reference_filepath, reference_metersetmap)
-    imageio.imwrite(evaluation_filepath, evaluation_metersetmap)
-    imageio.imwrite(diff_filepath, diff)
-    imageio.imwrite(gamma_filepath, gamma)
+    imageio.imwrite(
+        reference_filepath,
+        st_misc.normalize_and_convert_to_uint8(reference_metersetmap),
+    )
+    imageio.imwrite(
+        evaluation_filepath,
+        st_misc.normalize_and_convert_to_uint8(evaluation_metersetmap),
+    )
+    imageio.imwrite(diff_filepath, st_misc.normalize_and_convert_to_uint8(diff))
+    imageio.imwrite(gamma_filepath, st_misc.normalize_and_convert_to_uint8(gamma))
 
     largest_metersetmap = np.max(
         [np.max(evaluation_metersetmap), np.max(reference_metersetmap)]

--- a/lib/pymedphys/_streamlit/apps/metersetmap/main.py
+++ b/lib/pymedphys/_streamlit/apps/metersetmap/main.py
@@ -215,7 +215,7 @@ def get_input_data_ui(
     return results
 
 
-@st.cache
+@st.cache_data
 def to_tuple(array):
     return tuple(map(tuple, array))
 
@@ -321,7 +321,7 @@ def plot_and_save_results(
     return fig
 
 
-@st.cache(hash_funcs={pymedphys.Delivery: hash})
+@st.cache_data(hash_funcs={pymedphys.Delivery: hash})
 def calculate_metersetmap(delivery):
     return delivery.metersetmap(
         max_leaf_gap=MAX_LEAF_GAP,
@@ -339,7 +339,7 @@ def calculate_batch_metersetmap(deliveries):
     return metersetmap
 
 
-@st.cache
+@st.cache_data
 def calculate_gamma(reference_metersetmap, evaluation_metersetmap, gamma_options):
     gamma = pymedphys.gamma(
         COORDS,

--- a/lib/pymedphys/_streamlit/utilities/config.py
+++ b/lib/pymedphys/_streamlit/utilities/config.py
@@ -24,7 +24,7 @@ from typing_extensions import Literal
 from pymedphys import _config as pmp_config
 
 
-@st.cache
+@st.cache_data
 def get_config(path=None):
     result = pmp_config.get_config(path=path)
 
@@ -50,7 +50,7 @@ DirectoryConfigOptions = Literal[
 DirectoriesForSite = Dict[DirectoryConfigOptions, pathlib.Path]
 
 
-@st.cache
+@st.cache_data
 def get_site_directories(config) -> Dict[str, DirectoriesForSite]:
     """A config wrapper that retrieves a dictionary that maps site to directories.
 

--- a/lib/pymedphys/_streamlit/utilities/misc.py
+++ b/lib/pymedphys/_streamlit/utilities/misc.py
@@ -13,6 +13,8 @@ def normalize_and_convert_to_uint8(data, vmin, vmax):
     norm = (data - vmin) / (vmax - vmin)
     # Scale the data to suit a uint8 image
     img = 255 * norm
+    # make sure there are no out of bound values
+    img = np.clip(img, 0, 255)
 
     # Convert the data to uint8 format
     img = img.astype(np.uint8)

--- a/lib/pymedphys/_streamlit/utilities/misc.py
+++ b/lib/pymedphys/_streamlit/utilities/misc.py
@@ -3,8 +3,22 @@
 # pylint: disable = too-many-lines, redefined-outer-name
 
 from pymedphys._imports import streamlit as st
+from pymedphys._imports import numpy as np
 
 from . import config as _config
+
+
+def normalize_and_convert_to_uint8(data):
+    # Normalize the data to the range [0, 1]
+    data = data.astype(np.float64) / np.max(data)
+
+    # Scale the data to the range [0, 255]
+    data = 255 * data
+
+    # Convert the data to uint8 format
+    img = data.astype(np.uint8)
+
+    return img
 
 
 def site_picker(config, radio_label, default=None, key=None):

--- a/lib/pymedphys/_streamlit/utilities/misc.py
+++ b/lib/pymedphys/_streamlit/utilities/misc.py
@@ -2,8 +2,8 @@
 # pylint: disable = no-value-for-parameter, expression-not-assigned
 # pylint: disable = too-many-lines, redefined-outer-name
 
-from pymedphys._imports import streamlit as st
 from pymedphys._imports import numpy as np
+from pymedphys._imports import streamlit as st
 
 from . import config as _config
 

--- a/lib/pymedphys/_streamlit/utilities/misc.py
+++ b/lib/pymedphys/_streamlit/utilities/misc.py
@@ -8,15 +8,14 @@ from pymedphys._imports import streamlit as st
 from . import config as _config
 
 
-def normalize_and_convert_to_uint8(data):
-    # Normalize the data to the range [0, 1]
-    data = data.astype(np.float64) / np.max(data)
-
-    # Scale the data to the range [0, 255]
-    data = 255 * data
+def normalize_and_convert_to_uint8(data, vmin, vmax):
+    # Normalize the data so that when data = vmin, norm=0 and when data=vmax, norm=1
+    norm = (data - vmin) / (vmax - vmin)
+    # Scale the data to suit a uint8 image
+    img = 255 * norm
 
     # Convert the data to uint8 format
-    img = data.astype(np.uint8)
+    img = img.astype(np.uint8)
 
     return img
 

--- a/lib/pymedphys/_streamlit/utilities/monaco.py
+++ b/lib/pymedphys/_streamlit/utilities/monaco.py
@@ -166,6 +166,6 @@ def monaco_patient_directory_picker(
     return monaco_site, monaco_directory, patient_id, plan_directory, patient_directory
 
 
-@st.cache
+@st.cache_data
 def read_monaco_patient_name(monaco_patient_directory):
     return mnc_patient.read_patient_name(monaco_patient_directory)

--- a/lib/pymedphys/_streamlit/utilities/mosaiq.py
+++ b/lib/pymedphys/_streamlit/utilities/mosaiq.py
@@ -149,7 +149,7 @@ def get_uncached_mosaiq_connection(
     raise ValueError("This should never be reached")
 
 
-@st.cache(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_resource()
 def get_cached_mosaiq_connection(
     hostname: str, port: int = 1433, database: str = "MOSAIQ", alias=None
 ) -> _connect.Connection:
@@ -178,7 +178,7 @@ def get_cached_mosaiq_connection(
     )
 
 
-@st.cache(allow_output_mutation=True, suppress_st_warning=True)
+@st.cache_resource()
 def get_cached_mosaiq_connection_in_dict(
     hostname: str, port: int = 1433, database: str = "MOSAIQ", alias=None
 ) -> Dict[Literal["connection"], _connect.Connection]:


### PR DESCRIPTION
Mainly fixing the st.cache warnings in the streamlit gui. I changed most of the st.cache decorators to st.cache_data. For functions that return database connections to Mosaiq, I replaced them with st.cache_resource instead. see: https://docs.streamlit.io/develop/concepts/architecture/caching#deciding-which-caching-decorator-to-use

I also removed all allow_output_mutation=True, and suppress_st_warning as these do not exist in the new cache decorators. This is recommended in the migration manual: https://docs.streamlit.io/develop/concepts/architecture/caching#migrating-from-stcache

I tested the st.cache decorators using a mimic Microsoft SQL database, but it may require some more testing. The pytests will not test the streamlit gui. 

I was also getting an error when loading a trf file from file in the metersetmap gui, so I have put a solution in.

Another thing is that the newer imageio package doesn't allow saving arrays that have float type so I put a function in that converts to uint8 before saving. I've put that function in streamlit utilities misc.py. Is this a good location?

