### PR TITLE
Specify LIBRARY_PATH relative to current file

### DIFF
--- a/lib/pymedphys/_dev/paths.py
+++ b/lib/pymedphys/_dev/paths.py
@@ -16,5 +16,5 @@
 import pathlib
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent
-LIBRARY_PATH = REPO_ROOT.joinpath("lib", "pymedphys")
+LIBRARY_PATH = pathlib.Path(__file__).resolve().parent.parent
 DEPENDENCY_EXTRA_PATH = LIBRARY_PATH.joinpath("dependency-extra.txt")


### PR DESCRIPTION
**Summary**

This PR aims to fix #1880 by specifying the library path relative to the paths file it is in, instead of relying on directory structure and naming conventions.

**Tests performed**

- The automatic test suite was run successfully.
- A manual test was performed to verify that functions using `LIBRARY_PATH` can run successfully in nonstandard directory configurations.