### PR TITLE
Fix missing link in Release Notes

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -74,6 +74,8 @@ jobs:
   # =============================================================================
 
   Tests:
+    env:
+      FORCE_COLOR: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -18,6 +18,7 @@ jobs:
     services:
       SQLServer:
         image: mcr.microsoft.com/mssql/server:2017-latest
+        options: --user 10001:0
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: sqlServerPassw0rd

--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: sqlServerPassw0rd
+          HOME: /tmp
         ports:
           - 1433:1433
 

--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -120,6 +120,19 @@ jobs:
 
       ## Mosaiq_db tests -- only run on Ubuntu because needs container
 
+      - name: Wait for SQL Server to start
+        run: |
+          echo "Waiting for SQL Server..."
+          for i in {1..30}; do
+            if nc -z localhost 1433; then
+              echo "SQL Server is up!"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "SQL Server did not start in time"
+          exit 1
+
       - name: Run MSQ database tests
         run: |
           poetry run pymedphys dev tests -v --mosaiqdb

--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -12,6 +12,9 @@ jobs:
   TestMosaiqDb:
     # if: false
 
+    env:
+      FORCE_COLOR: true
+
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -17,12 +17,10 @@ jobs:
 
     services:
       SQLServer:
-        image: mcr.microsoft.com/mssql/server:2017-latest
-        options: --user 10001:0
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: sqlServerPassw0rd
-          HOME: /tmp
         ports:
           - 1433:1433
 
@@ -122,18 +120,18 @@ jobs:
 
       ## Mosaiq_db tests -- only run on Ubuntu because needs container
 
-      - name: Wait for SQL Server to start
-        run: |
-          echo "Waiting for SQL Server..."
-          for i in {1..30}; do
-            if nc -z localhost 1433; then
-              echo "SQL Server is up!"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "SQL Server did not start in time"
-          exit 1
+      # - name: Wait for SQL Server to start
+      #   run: |
+      #     echo "Waiting for SQL Server..."
+      #     for i in {1..30}; do
+      #       if nc -z localhost 1433; then
+      #         echo "SQL Server is up!"
+      #         exit 0
+      #       fi
+      #       sleep 2
+      #     done
+      #     echo "SQL Server did not start in time"
+      #     exit 1
 
       - name: Run MSQ database tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1418,6 +1418,7 @@ pymedphys.zip_data_paths("mu-density-gui-e2e-data.zip", extract_directory=CWD)
 - Began keeping record of changes in `changelog.md`
 
 [unreleased]: https://github.com/pymedphys/pymedphys/compare/v0.40.0...main
+[0.41.0]: https://github.com/pymedphys/pymedphys/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/pymedphys/pymedphys/compare/v0.39.3...v0.40.0
 [0.39.3]: https://github.com/pymedphys/pymedphys/compare/v0.39.2...v0.39.3
 [0.39.2]: https://github.com/pymedphys/pymedphys/compare/v0.39.1...v0.39.2


### PR DESCRIPTION
A nice quick one, @sjswerdloff, @SimonBiggs, @pchlap

Tested via local docs build

EDIT:
- Also seemed to have fixed the Mosaiq connection issue by using SQL Server 2022 instead of 2017
- Colorises `pytest` output to prettify logs in GitHub Actions 