### PR TITLE
Select first value of window width and first value of window center in CT slices for RT Visualisation

### DIFF
--- a/.github/workflows/mosaiq-db-tests.yml
+++ b/.github/workflows/mosaiq-db-tests.yml
@@ -52,7 +52,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-tests-ubuntu-${{ steps.full-python-version.outputs.version }}
@@ -80,7 +80,7 @@ jobs:
           poetry config virtualenvs.in-project true
 
       - name: Poetry Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: poetry-cache
         with:
           path: .venv
@@ -112,7 +112,7 @@ jobs:
 
       - name: PyMedPhys Cache
         id: pymedphys-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pymedphys-cache-location.outputs.dir }}
           key: pymedphys-tests-ubuntu-${{ hashFiles('**/hashes.json') }}


### PR DESCRIPTION
select first value of window width and first value of window center
provide additional exception handling and warning/logging when pre-processing CT to provide more detail on what actually failed and skip the slice rather than erroring out (in case there's just something wrong with that slice). 
If all of the slices have the same problem, it will still error out eventually and it will be clear that all of the slices have an issue or that the code has a problem with each of the slices.

