### PR TITLE
Just add the GitHub MCP tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -122,4 +122,6 @@ jobs:
             Bash(head),
             Bash(tail),
             Bash(which),
-            Bash(echo)
+            Bash(echo),
+            mcp__github_file_ops__commit_files,
+            mcp__github__create_pull_request


### PR DESCRIPTION
We can go with this to start if preferred.  (I honestly suspect it'd be okay to trial with the open bash approach, but also this change at least lets us start using it)