### PR TITLE
fix: update test strings to comply with DICOM VR length limits

### DIFF
--- a/lib/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
+++ b/lib/pymedphys/tests/experimental/pseudonymisation/test_pseudonymisation.py
@@ -171,8 +171,8 @@ def test_identifier_is_sequence_vr():
         "RequestAttributesSequence",
     ]
 
-    identifying_requested_procedure_id = "Tumour Identification"
-    non_identifying_scheduled_procedure_step_id = "Tumour ID with Dual Energy"
+    identifying_requested_procedure_id = "Tumour ID"
+    non_identifying_scheduled_procedure_step_id = "Dual Energy"
     ds_input = dicom_dataset_from_dict(
         {
             "PatientID": "ABC123",


### PR DESCRIPTION
Fixes #1738

The `test_identifier_is_sequence_vr` test was using strings that exceeded the 16 character limit for VR type SH (Short String):
- "Tumour Identification" (21 chars) -> "Tumour ID" (9 chars)
- "Tumour ID with Dual Energy" (26 chars) -> "Dual Energy" (11 chars)

This change eliminates the pydicom UserWarning about excessive value lengths while maintaining the test's functionality.

Generated with [Claude Code](https://claude.ai/code)