### PR TITLE
Mirror of #1956: exception handling for missing ToolType by @MattAWard

### DIFF
--- a/lib/pymedphys/_pinnacle/rtdose.py
+++ b/lib/pymedphys/_pinnacle/rtdose.py
@@ -141,13 +141,18 @@ def convert_dose(plan, export_path):
     ds.Modality = RTDOSEModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
-    ds.ManufacturerModelName = plan_info["ToolType"]
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]
     ds.PatientBirthDate = patient_info["DOB"]
     ds.PatientID = patient_info["MedicalRecordNumber"]
     ds.PatientSex = patient_info["Gender"][0]
+
+    try:
+        ds.ManufacturerModelName = plan_info["ToolType"]
+    except KeyError:
+        # Missing ToolType field
+        ds.ManufacturerModelName = ""
 
     ds.SliceThickness = trial_info["DoseGrid .VoxelSize .Z"] * 10
     ds.SeriesInstanceUID = doseInstanceUID

--- a/lib/pymedphys/_pinnacle/rtdose.py
+++ b/lib/pymedphys/_pinnacle/rtdose.py
@@ -141,18 +141,13 @@ def convert_dose(plan, export_path):
     ds.Modality = RTDOSEModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
+    ds.ManufacturerModelName = plan_info.get("ToolType", "")
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]
     ds.PatientBirthDate = patient_info["DOB"]
     ds.PatientID = patient_info["MedicalRecordNumber"]
     ds.PatientSex = patient_info["Gender"][0]
-
-    try:
-        ds.ManufacturerModelName = plan_info["ToolType"]
-    except KeyError:
-        # Missing ToolType field
-        ds.ManufacturerModelName = ""
 
     ds.SliceThickness = trial_info["DoseGrid .VoxelSize .Z"] * 10
     ds.SeriesInstanceUID = doseInstanceUID

--- a/lib/pymedphys/_pinnacle/rtplan.py
+++ b/lib/pymedphys/_pinnacle/rtplan.py
@@ -110,13 +110,18 @@ def convert_plan(plan, export_path):
     ds.Modality = RTPLANModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
-    ds.ManufacturersModelName = plan_info["ToolType"]
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]
     ds.PatientBirthDate = patient_info["DOB"]
     ds.PatientID = patient_info["MedicalRecordNumber"]
     ds.PatientSex = patient_info["Gender"][0]
+
+    try:
+        ds.ManufacturerModelName = plan_info["ToolType"]
+    except KeyError:
+        # Missing ToolType field
+        ds.ManufacturerModelName = ""
 
     ds.StudyInstanceUID = image_info["StudyInstanceUID"]
     ds.SeriesInstanceUID = planInstanceUID

--- a/lib/pymedphys/_pinnacle/rtplan.py
+++ b/lib/pymedphys/_pinnacle/rtplan.py
@@ -110,18 +110,13 @@ def convert_plan(plan, export_path):
     ds.Modality = RTPLANModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
+    ds.ManufacturerModelName = plan_info.get("ToolType", "")
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]
     ds.PatientBirthDate = patient_info["DOB"]
     ds.PatientID = patient_info["MedicalRecordNumber"]
     ds.PatientSex = patient_info["Gender"][0]
-
-    try:
-        ds.ManufacturerModelName = plan_info["ToolType"]
-    except KeyError:
-        # Missing ToolType field
-        ds.ManufacturerModelName = ""
 
     ds.StudyInstanceUID = image_info["StudyInstanceUID"]
     ds.SeriesInstanceUID = planInstanceUID

--- a/lib/pymedphys/_pinnacle/rtstruct.py
+++ b/lib/pymedphys/_pinnacle/rtstruct.py
@@ -468,16 +468,11 @@ def convert_struct(plan, export_path, skip_pattern):
     ds.StructureSetTime = study_time
     ds.StudyDate = study_date
     ds.StudyTime = study_time
+    ds.ManufacturerModelName = plan.plan_info.get("ToolType", "")
     ds.SoftwareVersions = plan.plan_info["PinnacleVersionDescription"]
     ds.StructureSetName = "POIandROI"
     ds.SeriesNumber = "1"
     ds.PatientName = patient_info["FullName"]
-
-    try:
-        ds.ManufacturerModelName = plan.plan_info["ToolType"]
-    except KeyError:
-        # Missing ToolType field
-        ds.ManufacturerModelName = ""
 
     ds.ReferencedFrameOfReferenceSequence = pydicom.sequence.Sequence()
     ReferencedFrameofReference = pydicom.dataset.Dataset()

--- a/lib/pymedphys/_pinnacle/rtstruct.py
+++ b/lib/pymedphys/_pinnacle/rtstruct.py
@@ -468,11 +468,16 @@ def convert_struct(plan, export_path, skip_pattern):
     ds.StructureSetTime = study_time
     ds.StudyDate = study_date
     ds.StudyTime = study_time
-    ds.ManufacturersModelName = plan.plan_info["ToolType"]
     ds.SoftwareVersions = plan.plan_info["PinnacleVersionDescription"]
     ds.StructureSetName = "POIandROI"
     ds.SeriesNumber = "1"
     ds.PatientName = patient_info["FullName"]
+
+    try:
+        ds.ManufacturerModelName = plan.plan_info["ToolType"]
+    except KeyError:
+        # Missing ToolType field
+        ds.ManufacturerModelName = ""
 
     ds.ReferencedFrameOfReferenceSequence = pydicom.sequence.Sequence()
     ReferencedFrameofReference = pydicom.dataset.Dataset()


### PR DESCRIPTION
This mirrors #1956 so CI can run with repo permissions.

All commits authored by @MattAWard are preserved.

Thanks @MattAWard. We will merge this one once CI passes and then close the original.

Supersedes #1956.