### PR TITLE
Revert "Mirror of #1956: exception handling for missing ToolType by @MattAWard"

### DIFF
--- a/lib/pymedphys/_pinnacle/rtdose.py
+++ b/lib/pymedphys/_pinnacle/rtdose.py
@@ -141,7 +141,7 @@ def convert_dose(plan, export_path):
     ds.Modality = RTDOSEModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
-    ds.ManufacturerModelName = plan_info.get("ToolType", "")
+    ds.ManufacturerModelName = plan_info["ToolType"]
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]

--- a/lib/pymedphys/_pinnacle/rtplan.py
+++ b/lib/pymedphys/_pinnacle/rtplan.py
@@ -110,7 +110,7 @@ def convert_plan(plan, export_path):
     ds.Modality = RTPLANModality
     ds.Manufacturer = Manufacturer
     ds.OperatorsName = ""
-    ds.ManufacturerModelName = plan_info.get("ToolType", "")
+    ds.ManufacturersModelName = plan_info["ToolType"]
     ds.SoftwareVersions = [plan_info["PinnacleVersionDescription"]]
     ds.PhysiciansOfRecord = patient_info["RadiationOncologist"]
     ds.PatientName = patient_info["FullName"]

--- a/lib/pymedphys/_pinnacle/rtstruct.py
+++ b/lib/pymedphys/_pinnacle/rtstruct.py
@@ -468,7 +468,7 @@ def convert_struct(plan, export_path, skip_pattern):
     ds.StructureSetTime = study_time
     ds.StudyDate = study_date
     ds.StudyTime = study_time
-    ds.ManufacturerModelName = plan.plan_info.get("ToolType", "")
+    ds.ManufacturersModelName = plan.plan_info["ToolType"]
     ds.SoftwareVersions = plan.plan_info["PinnacleVersionDescription"]
     ds.StructureSetName = "POIandROI"
     ds.SeriesNumber = "1"


### PR DESCRIPTION
Reverts pymedphys/pymedphys#1957

## Summary by Sourcery

Revert exception-safe fallback for missing ToolType in Pinnacle conversion modules and restore strict key access and field naming for ManufacturerModelName

Enhancements:
- Enforce strict presence of ToolType by replacing plan_info.get fallback with direct indexing in rtdose, rtplan, and rtstruct
- Restore original DICOM attribute naming by renaming ManufacturerModelName to ManufacturersModelName in rtplan and rtstruct