### PR TITLE
Add None checks in DVH serialisation tests and type ignore

### DIFF
--- a/lib/pymedphys/_dvh/_serialisation.py
+++ b/lib/pymedphys/_dvh/_serialisation.py
@@ -46,4 +46,4 @@ def from_json(json_str: str, cls: type[T]) -> T:
     T
         Deserialised instance.
     """
-    return cls.from_dict(json.loads(json_str))  # type: ignore[attr-defined]
+    return cls.from_dict(json.loads(json_str))  # type: ignore[attr-defined,no-any-return]

--- a/lib/pymedphys/tests/dvh/test_serialisation.py
+++ b/lib/pymedphys/tests/dvh/test_serialisation.py
@@ -200,6 +200,7 @@ class TestMetricRequestSetRoundTrip:
         d = mrs.to_dict()
         restored = MetricRequestSet.from_dict(d)
         assert len(restored.roi_requests) == 2
+        assert restored.dose_refs is not None
         assert "ptv60" in restored.dose_refs.refs
 
     def test_round_trip_preserves_roi_number(self) -> None:
@@ -426,6 +427,8 @@ class TestDVHResultSetRoundTrip:
         assert restored.schema_version == "1.0"
         assert len(restored.results) == 1
         assert restored.results[0].roi.name == "PTV"
+        assert restored.results[0].dvh is not None
+        assert rs.results[0].dvh is not None
         np.testing.assert_array_equal(
             restored.results[0].dvh.dose_bin_edges_gy,
             rs.results[0].dvh.dose_bin_edges_gy,
@@ -436,7 +439,9 @@ class TestDVHResultSetRoundTrip:
         d = rs.to_dict()
         restored = DVHResultSet.from_dict(d)
         assert restored.provenance.pymedphys_version == "0.42.0"
+        assert restored.provenance.input_metadata is not None
         assert restored.provenance.input_metadata.rtstruct_file_sha256 == "abc123"
+        assert restored.provenance.platform is not None
         assert restored.provenance.platform.python_version == "3.11.0"
 
     def test_metrics_preserved(self) -> None:


### PR DESCRIPTION
## Summary

Add defensive None checks in DVH serialisation tests to prevent potential AttributeErrors when accessing nested object properties, and update a type ignore comment to suppress an additional mypy warning.

## Why

The tests were accessing properties on objects that could potentially be None (e.g., `restored.dose_refs.refs`, `restored.results[0].dvh.dose_bin_edges_gy`, `restored.provenance.input_metadata.rtstruct_file_sha256`). While these should not be None in normal operation, adding explicit None checks makes the tests more robust and helps mypy understand the code flow. Additionally, the type ignore comment in `_serialisation.py` was incomplete and needed to suppress an additional `no-any-return` warning.

## What changed

- Added `assert restored.dose_refs is not None` check before accessing `restored.dose_refs.refs` in `test_sib_format`
- Added `assert restored.results[0].dvh is not None` and `assert rs.results[0].dvh is not None` checks before accessing DVH properties in `test_json_round_trip`
- Added `assert restored.provenance.input_metadata is not None` check before accessing metadata properties in `test_provenance_preserved`
- Added `assert restored.provenance.platform is not None` check before accessing platform properties in `test_provenance_preserved`
- Updated type ignore comment in `_serialisation.py` from `# type: ignore[attr-defined]` to `# type: ignore[attr-defined,no-any-return]`

## How was this tested?

Existing test suite passes with these changes. The modifications are defensive checks that don't alter test logic, only make assertions more explicit.

## Reviewer focus

These are defensive programming additions that make the code's assumptions explicit. The None checks should always pass in normal operation, but they help mypy understand the code flow and prevent potential AttributeErrors if the serialisation logic changes in the future.

## Breaking changes

* [x] None

## Documentation

* [x] Not needed

Checklist
* [x] The diff is focused
* [x] I added or updated tests, or explained why not needed
* [x] I updated docs, or explained why not needed
* [x] I noted any breaking changes
* [x] I linked the relevant issue/discussion when applicable

https://claude.ai/code/session_01FTxgZrWKJX5XyVUjhzaYo2

## Summary by Sourcery

Add defensive None assertions in DVH serialisation tests and broaden a mypy type ignore on the JSON deserialisation helper.

Bug Fixes:
- Prevent potential AttributeErrors in DVH serialisation tests by asserting nested objects are not None before accessing their attributes.

Enhancements:
- Make DVH serialisation tests more robust and mypy-friendly by explicitly asserting non-None DVH, dose reference, and provenance fields.

Tests:
- Tighten DVH serialisation round-trip and provenance tests with explicit non-None checks on restored objects and metadata.

Chores:
- Expand the type ignore on the JSON deserialisation helper to also suppress mypy's no-any-return warning.