### PR TITLE
Add type system regression tests and strengthen DVH validation

### DIFF
--- a/lib/pymedphys/_dvh/_benchmarks/__init__.py
+++ b/lib/pymedphys/_dvh/_benchmarks/__init__.py
@@ -5,9 +5,18 @@ Currently provides closed-form volume formulas for geometric primitives
 rectangular parallelepiped) used in the Tier 1 analytical benchmark
 suite. All inputs are in mm, all outputs are in mm³.
 
+Also provides a named benchmark-case registry for reusable ground-truth
+validation.
+
 See RFC §8.1 and §9 (Phase 1) for design rationale.
 """
 
+from pymedphys._dvh._benchmarks._cases import (
+    BENCHMARK_CASE_BY_ID,
+    BENCHMARK_CASES,
+    BenchmarkCase,
+    verify_registry_consistency,
+)
 from pymedphys._dvh._benchmarks._geometry import (
     MM3_PER_CC,
     cone_volume,
@@ -21,6 +30,9 @@ from pymedphys._dvh._benchmarks._geometry import (
 )
 
 __all__ = [
+    "BENCHMARK_CASES",
+    "BENCHMARK_CASE_BY_ID",
+    "BenchmarkCase",
     "MM3_PER_CC",
     "cone_volume",
     "cylinder_volume",
@@ -30,4 +42,5 @@ __all__ = [
     "rectangular_parallelepiped_volume",
     "sphere_volume",
     "torus_volume",
+    "verify_registry_consistency",
 ]

--- a/lib/pymedphys/_dvh/_benchmarks/_cases.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_cases.py
@@ -10,6 +10,7 @@ See RFC §8.1.1, §8.1.2 for specification.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Mapping
 
 import numpy as np
@@ -68,7 +69,7 @@ def _make_case(
     return BenchmarkCase(
         case_id=case_id,
         shape=shape,
-        parameters=dict(parameters),
+        parameters=MappingProxyType(dict(parameters)),
         expected_volume_mm3=volume_mm3,
         expected_volume_cc=mm3_to_cc(volume_mm3),
         tolerance_policy=tolerance_policy,

--- a/lib/pymedphys/_dvh/_benchmarks/_cases.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_cases.py
@@ -179,6 +179,6 @@ def verify_registry_consistency() -> None:
             f"Case {case.case_id}: formula gives {computed} mm³ but "
             f"registry says {case.expected_volume_mm3} mm³"
         )
-        assert np.isclose(mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12), (
-            f"Case {case.case_id}: cc conversion mismatch"
-        )
+        assert np.isclose(
+            mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12
+        ), f"Case {case.case_id}: cc conversion mismatch"

--- a/lib/pymedphys/_dvh/_benchmarks/_cases.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_cases.py
@@ -1,0 +1,183 @@
+"""Named benchmark cases for analytical volume validation.
+
+Each ``BenchmarkCase`` bundles a shape, its parameters, the expected
+closed-form volume, and a tolerance policy. Tests reference these
+canonical cases instead of re-stating expected values ad hoc.
+
+See RFC §8.1.1, §8.1.2 for specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+
+from pymedphys._dvh._benchmarks._geometry import (
+    cone_volume,
+    cylinder_volume,
+    cylindrical_shell_volume,
+    ellipsoid_volume,
+    mm3_to_cc,
+    rectangular_parallelepiped_volume,
+    sphere_volume,
+    torus_volume,
+)
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """A named analytical benchmark case.
+
+    Parameters
+    ----------
+    case_id : str
+        Unique human-readable identifier.
+    shape : str
+        Shape name (e.g. "sphere", "cylinder").
+    parameters : Mapping[str, float]
+        Shape parameters in mm.
+    expected_volume_mm3 : float
+        Analytically computed volume in mm³.
+    expected_volume_cc : float
+        Same volume in cc (1 cc = 1000 mm³).
+    tolerance_policy : str
+        Description of acceptable tolerance for voxelised comparison.
+    source_note : str
+        Reference or provenance note.
+    """
+
+    case_id: str
+    shape: str
+    parameters: Mapping[str, float]
+    expected_volume_mm3: float
+    expected_volume_cc: float
+    tolerance_policy: str
+    source_note: str
+
+
+def _make_case(
+    case_id: str,
+    shape: str,
+    parameters: Mapping[str, float],
+    volume_mm3: float,
+    tolerance_policy: str = "rel=1e-9 for analytical, <1% for voxelised",
+    source_note: str = "closed-form formula",
+) -> BenchmarkCase:
+    return BenchmarkCase(
+        case_id=case_id,
+        shape=shape,
+        parameters=dict(parameters),
+        expected_volume_mm3=volume_mm3,
+        expected_volume_cc=mm3_to_cc(volume_mm3),
+        tolerance_policy=tolerance_policy,
+        source_note=source_note,
+    )
+
+
+# ── Canonical benchmark cases ──────────────────────────────────────
+
+BENCHMARK_CASES: tuple[BenchmarkCase, ...] = (
+    _make_case(
+        case_id="sphere_r10",
+        shape="sphere",
+        parameters={"radius_mm": 10.0},
+        volume_mm3=sphere_volume(10.0),
+        source_note="RFC §9 Task 1.1",
+    ),
+    _make_case(
+        case_id="sphere_r1",
+        shape="sphere",
+        parameters={"radius_mm": 1.0},
+        volume_mm3=sphere_volume(1.0),
+        source_note="unit sphere: V = 4π/3",
+    ),
+    _make_case(
+        case_id="cylinder_r12_h24",
+        shape="cylinder",
+        parameters={"radius_mm": 12.0, "height_mm": 24.0},
+        volume_mm3=cylinder_volume(12.0, 24.0),
+        source_note="Nelms et al. [14]",
+    ),
+    _make_case(
+        case_id="cone_r12_h24",
+        shape="cone",
+        parameters={"radius_mm": 12.0, "height_mm": 24.0},
+        volume_mm3=cone_volume(12.0, 24.0),
+        source_note="Nelms et al. [14]",
+    ),
+    _make_case(
+        case_id="ellipsoid_10_5_3",
+        shape="ellipsoid",
+        parameters={"semi_a_mm": 10.0, "semi_b_mm": 5.0, "semi_c_mm": 3.0},
+        volume_mm3=ellipsoid_volume(10.0, 5.0, 3.0),
+    ),
+    _make_case(
+        case_id="torus_R20_r5",
+        shape="torus",
+        parameters={"major_radius_mm": 20.0, "minor_radius_mm": 5.0},
+        volume_mm3=torus_volume(20.0, 5.0),
+    ),
+    _make_case(
+        case_id="shell_R11_r10_h20",
+        shape="cylindrical_shell",
+        parameters={
+            "outer_radius_mm": 11.0,
+            "inner_radius_mm": 10.0,
+            "height_mm": 20.0,
+        },
+        volume_mm3=cylindrical_shell_volume(11.0, 10.0, 20.0),
+    ),
+    _make_case(
+        case_id="box_10_10_10",
+        shape="rectangular_parallelepiped",
+        parameters={"length_mm": 10.0, "width_mm": 10.0, "height_mm": 10.0},
+        volume_mm3=rectangular_parallelepiped_volume(10.0, 10.0, 10.0),
+        source_note="10mm cube = 1000 mm³ = 1.0 cc",
+    ),
+)
+
+
+# Lookup by case_id for convenience
+BENCHMARK_CASE_BY_ID: Mapping[str, BenchmarkCase] = {
+    c.case_id: c for c in BENCHMARK_CASES
+}
+
+
+# Shape → volume function mapping for verification
+_SHAPE_VOLUME_FUNCTIONS = {
+    "sphere": lambda p: sphere_volume(p["radius_mm"]),
+    "cylinder": lambda p: cylinder_volume(p["radius_mm"], p["height_mm"]),
+    "cone": lambda p: cone_volume(p["radius_mm"], p["height_mm"]),
+    "ellipsoid": lambda p: ellipsoid_volume(
+        p["semi_a_mm"], p["semi_b_mm"], p["semi_c_mm"]
+    ),
+    "torus": lambda p: torus_volume(p["major_radius_mm"], p["minor_radius_mm"]),
+    "cylindrical_shell": lambda p: cylindrical_shell_volume(
+        p["outer_radius_mm"], p["inner_radius_mm"], p["height_mm"]
+    ),
+    "rectangular_parallelepiped": lambda p: rectangular_parallelepiped_volume(
+        p["length_mm"], p["width_mm"], p["height_mm"]
+    ),
+}
+
+
+def verify_registry_consistency() -> None:
+    """Verify that all registered cases match their volume formulas.
+
+    Raises
+    ------
+    AssertionError
+        If any case's expected volume doesn't match the formula output.
+    """
+    for case in BENCHMARK_CASES:
+        fn = _SHAPE_VOLUME_FUNCTIONS[case.shape]
+        computed = fn(case.parameters)
+        assert np.isclose(computed, case.expected_volume_mm3, rtol=1e-12), (
+            f"Case {case.case_id}: formula gives {computed} mm³ but "
+            f"registry says {case.expected_volume_mm3} mm³"
+        )
+        assert np.isclose(mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12), (
+            f"Case {case.case_id}: cc conversion mismatch"
+        )

--- a/lib/pymedphys/_dvh/_benchmarks/_cases.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_cases.py
@@ -179,6 +179,6 @@ def verify_registry_consistency() -> None:
             f"Case {case.case_id}: formula gives {computed} mm³ but "
             f"registry says {case.expected_volume_mm3} mm³"
         )
-        assert np.isclose(
-            mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12
-        ), f"Case {case.case_id}: cc conversion mismatch"
+        assert np.isclose(mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12), (
+            f"Case {case.case_id}: cc conversion mismatch"
+        )

--- a/lib/pymedphys/_dvh/_benchmarks/_cases.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_cases.py
@@ -178,6 +178,6 @@ def verify_registry_consistency() -> None:
             f"Case {case.case_id}: formula gives {computed} mm³ but "
             f"registry says {case.expected_volume_mm3} mm³"
         )
-        assert np.isclose(mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12), (
-            f"Case {case.case_id}: cc conversion mismatch"
-        )
+        assert np.isclose(
+            mm3_to_cc(computed), case.expected_volume_cc, rtol=1e-12
+        ), f"Case {case.case_id}: cc conversion mismatch"

--- a/lib/pymedphys/_dvh/_benchmarks/_geometry.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_geometry.py
@@ -123,12 +123,19 @@ def ellipsoid_volume(semi_a_mm: float, semi_b_mm: float, semi_c_mm: float) -> fl
 
 
 def torus_volume(major_radius_mm: float, minor_radius_mm: float) -> float:
-    """Volume of a torus.
+    """Volume of a simple (non-self-intersecting) torus.
+
+    Only simple tori (``major_radius_mm > minor_radius_mm``) are
+    supported. Horn tori (``R == r``) and spindle tori (``R < r``)
+    are rejected because they are not useful benchmark shapes and
+    their volume formula yields the same algebraic result but their
+    geometry is self-intersecting.
 
     Parameters
     ----------
     major_radius_mm : float
-        Distance from torus centre to tube centre, in mm. Must be > 0.
+        Distance from torus centre to tube centre, in mm. Must be
+        strictly greater than ``minor_radius_mm``.
     minor_radius_mm : float
         Tube radius in mm. Must be > 0.
 
@@ -136,8 +143,19 @@ def torus_volume(major_radius_mm: float, minor_radius_mm: float) -> float:
     -------
     float
         Volume in mm³: ``2 * π² * R * r²``.
+
+    Raises
+    ------
+    ValueError
+        If ``major_radius_mm <= minor_radius_mm``.
     """
     _validate_positive(major_radius_mm=major_radius_mm, minor_radius_mm=minor_radius_mm)
+    if major_radius_mm <= minor_radius_mm:
+        raise ValueError(
+            f"major_radius_mm ({major_radius_mm}) must be strictly greater "
+            f"than minor_radius_mm ({minor_radius_mm}) for a simple "
+            f"(non-self-intersecting) torus"
+        )
     return 2.0 * np.pi**2 * major_radius_mm * minor_radius_mm**2
 
 

--- a/lib/pymedphys/_dvh/_benchmarks/_geometry.py
+++ b/lib/pymedphys/_dvh/_benchmarks/_geometry.py
@@ -60,7 +60,7 @@ def sphere_volume(radius_mm: float) -> float:
         Volume in mm³: ``(4/3) * π * r³``.
     """
     _validate_positive(radius_mm=radius_mm)
-    return (4.0 / 3.0) * np.pi * radius_mm**3
+    return float((4.0 / 3.0) * np.pi * radius_mm**3)
 
 
 def cylinder_volume(radius_mm: float, height_mm: float) -> float:
@@ -79,7 +79,7 @@ def cylinder_volume(radius_mm: float, height_mm: float) -> float:
         Volume in mm³: ``π * r² * h``.
     """
     _validate_positive(radius_mm=radius_mm, height_mm=height_mm)
-    return np.pi * radius_mm**2 * height_mm
+    return float(np.pi * radius_mm**2 * height_mm)
 
 
 def cone_volume(radius_mm: float, height_mm: float) -> float:
@@ -98,7 +98,7 @@ def cone_volume(radius_mm: float, height_mm: float) -> float:
         Volume in mm³: ``(1/3) * π * r² * h``.
     """
     _validate_positive(radius_mm=radius_mm, height_mm=height_mm)
-    return (1.0 / 3.0) * np.pi * radius_mm**2 * height_mm
+    return float((1.0 / 3.0) * np.pi * radius_mm**2 * height_mm)
 
 
 def ellipsoid_volume(semi_a_mm: float, semi_b_mm: float, semi_c_mm: float) -> float:
@@ -119,7 +119,7 @@ def ellipsoid_volume(semi_a_mm: float, semi_b_mm: float, semi_c_mm: float) -> fl
         Volume in mm³: ``(4/3) * π * a * b * c``.
     """
     _validate_positive(semi_a_mm=semi_a_mm, semi_b_mm=semi_b_mm, semi_c_mm=semi_c_mm)
-    return (4.0 / 3.0) * np.pi * semi_a_mm * semi_b_mm * semi_c_mm
+    return float((4.0 / 3.0) * np.pi * semi_a_mm * semi_b_mm * semi_c_mm)
 
 
 def torus_volume(major_radius_mm: float, minor_radius_mm: float) -> float:
@@ -156,7 +156,7 @@ def torus_volume(major_radius_mm: float, minor_radius_mm: float) -> float:
             f"than minor_radius_mm ({minor_radius_mm}) for a simple "
             f"(non-self-intersecting) torus"
         )
-    return 2.0 * np.pi**2 * major_radius_mm * minor_radius_mm**2
+    return float(2.0 * np.pi**2 * major_radius_mm * minor_radius_mm**2)
 
 
 def cylindrical_shell_volume(
@@ -193,7 +193,7 @@ def cylindrical_shell_volume(
             f"outer_radius_mm ({outer_radius_mm}) must be strictly greater "
             f"than inner_radius_mm ({inner_radius_mm})"
         )
-    return np.pi * (outer_radius_mm**2 - inner_radius_mm**2) * height_mm
+    return float(np.pi * (outer_radius_mm**2 - inner_radius_mm**2) * height_mm)
 
 
 def rectangular_parallelepiped_volume(

--- a/lib/pymedphys/_dvh/_serialisation.py
+++ b/lib/pymedphys/_dvh/_serialisation.py
@@ -1,10 +1,11 @@
-"""JSON/TOML serialisation for DVH types.
+"""JSON wrappers over per-type ``to_dict()`` / ``from_dict()`` methods.
 
-- **TOML** for human-edited inputs (metric requests, configuration).
-- **JSON** for machine-generated results (DVHResultSet output).
+Each serialisable DVH type defines its own ``to_dict()`` and
+``from_dict()`` round-trip methods. This module provides thin
+convenience wrappers for converting to and from JSON strings.
 
-Each serialisable type has its own ``to_dict()`` and ``from_dict()``
-methods. This module provides thin wrappers for JSON string conversion.
+TOML input (where supported) is handled by type-specific loaders
+such as ``MetricRequestSet.from_toml()``, not by this module.
 """
 
 from __future__ import annotations

--- a/lib/pymedphys/_dvh/_types/__init__.py
+++ b/lib/pymedphys/_dvh/_types/__init__.py
@@ -26,6 +26,7 @@ from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._inputs import DVHInputs
 from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel
 from pymedphys._dvh._types._metrics import (
+    IndexMetric,
     MetricFamily,
     MetricRequestSet,
     MetricSpec,
@@ -43,6 +44,7 @@ from pymedphys._dvh._types._results import (
     ProvenanceRecord,
     ROIDiagnostics,
     ROIResult,
+    ROIStatus,
 )
 from pymedphys._dvh._types._roi_ref import ROIRef
 from pymedphys._dvh._types._sdf import SDFField
@@ -63,6 +65,7 @@ __all__ = [
     "EndCapPolicy",
     "FloatingPointPrecision",
     "GridFrame",
+    "IndexMetric",
     "InputMetadata",
     "InterpolationMethod",
     "InvalidROIPolicy",
@@ -84,6 +87,7 @@ __all__ = [
     "ROIDiagnostics",
     "ROIMetricRequest",
     "ROIResult",
+    "ROIStatus",
     "ROIRef",
     "RuntimeConfig",
     "SDFField",

--- a/lib/pymedphys/_dvh/_types/_dose_ref.py
+++ b/lib/pymedphys/_dvh/_types/_dose_ref.py
@@ -84,18 +84,18 @@ class DoseReferenceSet:
     def __post_init__(self) -> None:
         if not self.refs:
             raise ValueError("DoseReferenceSet must contain at least one reference")
-        # Defensive copy + freeze with MappingProxyType
-        frozen = MappingProxyType(dict(self.refs))
-        object.__setattr__(self, "refs", frozen)
+        # Validate all keys before freezing
+        for key in self.refs:
+            if not key or not key.strip():
+                raise ValueError("DoseReferenceSet ref keys must be non-empty")
         if self.default_id is not None and self.default_id not in self.refs:
             raise ValueError(
                 f"default_id '{self.default_id}' not found in refs: "
                 f"{list(self.refs.keys())}"
             )
-        # Validate all keys are non-empty strings
-        for key in self.refs:
-            if not key or not key.strip():
-                raise ValueError("DoseReferenceSet ref keys must be non-empty")
+        # Defensive copy + freeze with MappingProxyType
+        frozen = MappingProxyType(dict(self.refs))
+        object.__setattr__(self, "refs", frozen)
 
     @property
     def default(self) -> Optional[DoseReference]:

--- a/lib/pymedphys/_dvh/_types/_dose_ref.py
+++ b/lib/pymedphys/_dvh/_types/_dose_ref.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Mapping, Optional
+
+import numpy as np
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,16 +20,19 @@ class DoseReference:
     Parameters
     ----------
     dose_gy : float
-        Reference dose in Gy. Must be strictly positive.
+        Reference dose in Gy. Must be strictly positive and finite.
     source : str
-        Human-readable provenance string (>= 5 characters). Forces the
-        user to document where the reference dose came from.
+        Human-readable provenance string (>= 5 characters). Must
+        contain at least one alphabetic character. Forces the user to
+        document where the reference dose came from.
     """
 
     dose_gy: float
     source: str
 
     def __post_init__(self) -> None:
+        if not np.isfinite(self.dose_gy):
+            raise ValueError(f"Reference dose must be finite, got {self.dose_gy}")
         if self.dose_gy <= 0:
             raise ValueError(f"Reference dose must be positive, got {self.dose_gy}")
         stripped = self.source.strip()
@@ -39,6 +46,11 @@ class DoseReference:
                 f"DoseReference.source must be at least 5 characters "
                 f"(got '{stripped}'). Provide a meaningful description of "
                 f"where this dose reference comes from."
+            )
+        if not re.search(r"[a-zA-Z]", stripped):
+            raise ValueError(
+                f"DoseReference.source must contain at least one "
+                f"alphabetic character, got '{stripped}'"
             )
 
     def to_dict(self) -> dict:
@@ -72,11 +84,18 @@ class DoseReferenceSet:
     def __post_init__(self) -> None:
         if not self.refs:
             raise ValueError("DoseReferenceSet must contain at least one reference")
+        # Defensive copy + freeze with MappingProxyType
+        frozen = MappingProxyType(dict(self.refs))
+        object.__setattr__(self, "refs", frozen)
         if self.default_id is not None and self.default_id not in self.refs:
             raise ValueError(
                 f"default_id '{self.default_id}' not found in refs: "
                 f"{list(self.refs.keys())}"
             )
+        # Validate all keys are non-empty strings
+        for key in self.refs:
+            if not key or not key.strip():
+                raise ValueError("DoseReferenceSet ref keys must be non-empty")
 
     @property
     def default(self) -> Optional[DoseReference]:

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -195,7 +195,11 @@ class GridFrame:
     def from_dict(cls, d: dict) -> GridFrame:
         """Deserialise from a plain dict."""
         raw_shape = d["shape_zyx"]
-        coerced = []
+        if len(raw_shape) != 3:
+            raise ValueError(
+                f"shape_zyx must have exactly 3 elements, got {len(raw_shape)}"
+            )
+        coerced: list[int] = []
         for v in raw_shape:
             fv = float(v)
             iv = int(fv)
@@ -205,6 +209,6 @@ class GridFrame:
                 raise ValueError(f"shape_zyx values must be positive, got {iv}")
             coerced.append(iv)
         return cls(
-            shape_zyx=tuple(coerced),
+            shape_zyx=(coerced[0], coerced[1], coerced[2]),
             index_to_patient_mm=np.array(d["index_to_patient_mm"], dtype=np.float64),
         )

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -13,6 +13,13 @@ from pymedphys._dvh._types._validators import _validate_finite_array
 def _validate_axis_aligned_affine(aff: npt.NDArray[np.float64]) -> None:
     """Enforce v1 axis-aligned affine constraints.
 
+    The affine must be axis-aligned with no shear. Each column and
+    each row of the 3x3 linear submatrix must have exactly one
+    non-zero entry. Sign flips (negative spacing) are allowed.
+    Axis permutation is allowed because the standard
+    ``from_uniform()`` constructor maps (iz, iy, ix) index axes to
+    (x, y, z) patient axes, which requires a permutation.
+
     Parameters
     ----------
     aff : npt.NDArray[np.float64]
@@ -23,8 +30,8 @@ def _validate_axis_aligned_affine(aff: npt.NDArray[np.float64]) -> None:
     ValueError
         If the affine violates axis-aligned constraints: last row
         must be [0, 0, 0, 1], the 3x3 linear submatrix must have
-        exactly one non-zero entry per column (axis-aligned, no shear),
-        and axes must be orthogonal.
+        exactly one non-zero entry per column and per row (axis-aligned,
+        no shear), and axes must be orthogonal.
     """
     # Last row must be [0, 0, 0, 1]
     expected_last_row = np.array([0.0, 0.0, 0.0, 1.0])
@@ -77,8 +84,10 @@ class GridFrame:
 
     v1 restriction: axis-aligned grids only. The affine must have
     orthogonal axes with exactly one non-zero spatial term per index
-    axis (no shear, no rotation other than axis permutation), and
-    the last row must be ``[0, 0, 0, 1]``.
+    axis and per output axis (no shear). Sign flips and axis
+    permutation are allowed (the standard ``from_uniform()``
+    constructor uses a permutation to map (iz, iy, ix) to (x, y, z)).
+    The last row must be ``[0, 0, 0, 1]``.
 
     Parameters
     ----------
@@ -186,6 +195,6 @@ class GridFrame:
     def from_dict(cls, d: dict) -> GridFrame:
         """Deserialise from a plain dict."""
         return cls(
-            shape_zyx=tuple(d["shape_zyx"]),
+            shape_zyx=tuple(int(v) for v in d["shape_zyx"]),
             index_to_patient_mm=np.array(d["index_to_patient_mm"], dtype=np.float64),
         )

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -194,7 +194,17 @@ class GridFrame:
     @classmethod
     def from_dict(cls, d: dict) -> GridFrame:
         """Deserialise from a plain dict."""
+        raw_shape = d["shape_zyx"]
+        coerced = []
+        for v in raw_shape:
+            fv = float(v)
+            iv = int(fv)
+            if fv != iv:
+                raise ValueError(f"shape_zyx values must be integers, got {v!r}")
+            if iv <= 0:
+                raise ValueError(f"shape_zyx values must be positive, got {iv}")
+            coerced.append(iv)
         return cls(
-            shape_zyx=tuple(int(v) for v in d["shape_zyx"]),
+            shape_zyx=tuple(coerced),
             index_to_patient_mm=np.array(d["index_to_patient_mm"], dtype=np.float64),
         )

--- a/lib/pymedphys/_dvh/_types/_metrics.py
+++ b/lib/pymedphys/_dvh/_types/_metrics.py
@@ -20,6 +20,25 @@ class MetricFamily(str, Enum):
     INDEX = "index"
 
 
+class IndexMetric(str, Enum):
+    """Typed enumeration of conformity/homogeneity index metrics.
+
+    Using a typed enum instead of raw strings makes the
+    ``requires_dose_ref`` check structural rather than string-based,
+    and prevents typos from silently creating unknown index metrics.
+    """
+
+    HI = "HI"
+    CI = "CI"
+    PCI = "PCI"
+    GI = "GI"
+
+    @property
+    def requires_dose_ref(self) -> bool:
+        """Whether this index metric needs a DoseReference."""
+        return self in {IndexMetric.CI, IndexMetric.PCI, IndexMetric.GI}
+
+
 class ThresholdUnit(str, Enum):
     """Unit of the threshold/input axis."""
 
@@ -46,11 +65,9 @@ class MetricSpec:
     This is the metric AST — a structured representation that is
     unambiguous about what is being computed and in what unit.
 
-    Dose reference binding is handled at the ROI level
-    (``ROIMetricRequest.dose_ref_id``) or at the global level
-    (``MetricRequestSet.dose_refs.default_id``), not per-metric.
-    This simplifies the v1 semantics and avoids partial
-    implementation of per-metric dose references.
+    Dose reference resolution precedence (most specific wins)::
+
+        metric.dose_ref_id  or  roi_request.dose_ref_id  or  dose_refs.default_id
 
     Parameters
     ----------
@@ -64,6 +81,12 @@ class MetricSpec:
         Unit of the metric output.
     raw : str
         Original string, preserved for display/provenance.
+    index_metric : IndexMetric, optional
+        Typed index metric kind. Set when ``family == INDEX``.
+    dose_ref_id : str, optional
+        Per-metric dose reference override. Takes precedence over
+        ``ROIMetricRequest.dose_ref_id`` and
+        ``DoseReferenceSet.default_id``.
     """
 
     family: MetricFamily
@@ -71,12 +94,17 @@ class MetricSpec:
     threshold_unit: ThresholdUnit = ThresholdUnit.NONE
     output_unit: OutputUnit = OutputUnit.GY
     raw: str = ""
+    index_metric: Optional[IndexMetric] = None
+    dose_ref_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.threshold is not None and self.threshold < 0:
             raise ValueError(
                 f"Metric threshold must be non-negative, got {self.threshold}"
             )
+        if self.family == MetricFamily.INDEX and self.index_metric is None:
+            if self.raw in {m.value for m in IndexMetric}:
+                object.__setattr__(self, "index_metric", IndexMetric(self.raw))
 
     @property
     def requires_dose_ref(self) -> bool:
@@ -88,12 +116,8 @@ class MetricSpec:
             return True
         if self.output_unit == OutputUnit.PERCENT_DOSE:
             return True
-        if self.family == MetricFamily.INDEX and self.raw in {
-            "CI",
-            "PCI",
-            "GI",
-        }:
-            return True
+        if self.family == MetricFamily.INDEX and self.index_metric is not None:
+            return self.index_metric.requires_dose_ref
         return False
 
     @property
@@ -116,17 +140,24 @@ class MetricSpec:
         }
         if self.threshold is not None:
             d["threshold"] = self.threshold
+        if self.index_metric is not None:
+            d["index_metric"] = self.index_metric.value
+        if self.dose_ref_id is not None:
+            d["dose_ref_id"] = self.dose_ref_id
         return d
 
     @classmethod
     def from_dict(cls, d: dict) -> MetricSpec:
         """Deserialise from a plain dict."""
+        idx = d.get("index_metric")
         return cls(
             family=MetricFamily(d["family"]),
             threshold=d.get("threshold"),
             threshold_unit=ThresholdUnit(d["threshold_unit"]),
             output_unit=OutputUnit(d["output_unit"]),
             raw=d.get("raw", ""),
+            index_metric=IndexMetric(idx) if idx is not None else None,
+            dose_ref_id=d.get("dose_ref_id"),
         )
 
     @classmethod
@@ -143,7 +174,8 @@ class MetricSpec:
             V{x}Gy             -> DVH_VOLUME, threshold=x, unit=GY, out=CC
             V{x}Gy[%]          -> DVH_VOLUME, threshold=x, unit=GY, out=PERCENT_VOLUME
             V{x}%              -> DVH_VOLUME, threshold=x, unit=PERCENT, out=CC
-            mean|median|min|max -> SCALAR
+            mean|median|min|max -> SCALAR, out=GY
+            mean[%Rx]           -> SCALAR, out=PERCENT_DOSE
             HI|CI|PCI|GI       -> INDEX
 
         Raises
@@ -156,6 +188,14 @@ class MetricSpec:
 
         s = raw.strip()
 
+        # Scalar metrics with optional %Rx output modifier
+        if s == "mean[%Rx]":
+            return cls(
+                family=MetricFamily.SCALAR,
+                output_unit=OutputUnit.PERCENT_DOSE,
+                raw=raw,
+            )
+
         # Scalar metrics
         if s in {"mean", "median", "min", "max"}:
             return cls(
@@ -164,13 +204,17 @@ class MetricSpec:
                 raw=raw,
             )
 
-        # Index metrics
-        if s in {"HI", "CI", "PCI", "GI"}:
+        # Index metrics — use typed IndexMetric enum
+        try:
+            idx = IndexMetric(s)
             return cls(
                 family=MetricFamily.INDEX,
                 output_unit=OutputUnit.DIMENSIONLESS,
                 raw=raw,
+                index_metric=idx,
             )
+        except ValueError:
+            pass
 
         # Parametric DVH metrics: (pattern, family, threshold_unit, output_unit)
         _dvh_patterns: tuple[
@@ -313,7 +357,8 @@ class MetricRequestSet:
         for rr in self.roi_requests:
             for m in rr.metrics:
                 if m.requires_dose_ref:
-                    ref_id = rr.dose_ref_id
+                    # Resolution precedence: metric > ROI > global default
+                    ref_id = m.dose_ref_id or rr.dose_ref_id
                     if self.dose_refs is None:
                         raise ValueError(
                             f"Metric '{m.raw}' for ROI '{rr.roi}' requires a "

--- a/lib/pymedphys/_dvh/_types/_metrics.py
+++ b/lib/pymedphys/_dvh/_types/_metrics.py
@@ -105,6 +105,12 @@ class MetricSpec:
         if self.family == MetricFamily.INDEX and self.index_metric is None:
             if self.raw in {m.value for m in IndexMetric}:
                 object.__setattr__(self, "index_metric", IndexMetric(self.raw))
+            else:
+                raise ValueError(
+                    f"MetricSpec with family=INDEX requires a known "
+                    f"index_metric, but raw={self.raw!r} does not match "
+                    f"any IndexMetric value: {[m.value for m in IndexMetric]}"
+                )
 
     @property
     def requires_dose_ref(self) -> bool:
@@ -128,6 +134,8 @@ class MetricSpec:
             parts.append(f"{self.threshold}")
         parts.append(self.threshold_unit.value)
         parts.append(self.output_unit.value)
+        if self.index_metric is not None:
+            parts.append(self.index_metric.value)
         return "|".join(parts)
 
     def to_dict(self) -> dict:
@@ -382,12 +390,7 @@ class MetricRequestSet:
         """
         d: dict = {}
         if self.dose_refs is not None:
-            d["dose_refs"] = {
-                k: {"dose_gy": v.dose_gy, "source": v.source}
-                for k, v in self.dose_refs.refs.items()
-            }
-            if self.dose_refs.default_id is not None:
-                d["default_dose_ref"] = self.dose_refs.default_id
+            d["dose_refs"] = self.dose_refs.to_dict()
         d["roi_requests"] = [rr.to_dict() for rr in self.roi_requests]
         return d
 
@@ -414,13 +417,19 @@ class MetricRequestSet:
         """
         dose_refs = None
         if "dose_refs" in d:
-            refs = {
-                k: DoseReference(dose_gy=v["dose_gy"], source=v["source"])
-                for k, v in d["dose_refs"].items()
-            }
-            dose_refs = DoseReferenceSet(
-                refs=refs, default_id=d.get("default_dose_ref")
-            )
+            raw_refs = d["dose_refs"]
+            if "refs" in raw_refs:
+                # Canonical format from DoseReferenceSet.to_dict()
+                dose_refs = DoseReferenceSet.from_dict(raw_refs)
+            else:
+                # Legacy inline format: flat dict of {id: {dose_gy, source}}
+                refs = {
+                    k: DoseReference(dose_gy=v["dose_gy"], source=v["source"])
+                    for k, v in raw_refs.items()
+                }
+                dose_refs = DoseReferenceSet(
+                    refs=refs, default_id=d.get("default_dose_ref")
+                )
         elif "dose_ref_gy" in d:
             source = d.get("dose_ref_source")
             if not source or not source.strip():

--- a/lib/pymedphys/_dvh/_types/_results.py
+++ b/lib/pymedphys/_dvh/_types/_results.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import FrozenSet, Literal, Optional, get_args
 
@@ -19,7 +19,6 @@ from pymedphys._dvh._types._roi_ref import ROIRef
 from pymedphys._dvh._types._validators import (
     _validate_nonneg_array,
     _validate_nonneg_finite,
-    _validate_positive_finite,
     _validate_strictly_increasing,
 )
 
@@ -205,7 +204,7 @@ class DVHBins:
             (
                 self.dose_bin_edges_gy.tobytes(),
                 self.differential_volume_cc.tobytes(),
-                float(self.total_volume_cc),
+                self.total_volume_cc,
             )
         )
 
@@ -302,7 +301,7 @@ class ROIDiagnostics:
         ):
             val = getattr(self, name)
             if val is not None:
-                if not isinstance(val, int) or val < 0:
+                if isinstance(val, bool) or not isinstance(val, int) or val < 0:
                     raise ValueError(
                         f"ROIDiagnostics.{name} must be a non-negative "
                         f"integer, got {val!r}"
@@ -402,9 +401,7 @@ class ROIResult:
     def to_dict(self) -> dict:
         d: dict = {
             "roi": self.roi.to_dict(),
-            "status": self.status.value
-            if isinstance(self.status, ROIStatus)
-            else self.status,
+            "status": self.status.value,
         }
         if self.volume_cc is not None:
             d["volume_cc"] = self.volume_cc
@@ -573,8 +570,13 @@ class ProvenanceRecord:
 
     def __post_init__(self) -> None:
         if self.timestamp_utc:
+            # Normalise 'Z' → '+00:00' for Python 3.10 compatibility
+            # (datetime.fromisoformat only accepts 'Z' from 3.11+).
+            ts = self.timestamp_utc
+            if ts.endswith("Z"):
+                ts = ts[:-1] + "+00:00"
             try:
-                dt = datetime.fromisoformat(self.timestamp_utc)
+                dt = datetime.fromisoformat(ts)
             except (ValueError, TypeError):
                 raise ValueError(
                     f"ProvenanceRecord.timestamp_utc must be a valid ISO 8601 "

--- a/lib/pymedphys/_dvh/_types/_results.py
+++ b/lib/pymedphys/_dvh/_types/_results.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import FrozenSet, Literal, Optional, get_args
 
@@ -14,7 +14,7 @@ from pymedphys._dvh._types._config import DVHConfig
 from pymedphys._dvh._types._dose_ref import DoseReferenceSet
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._issues import Issue
-from pymedphys._dvh._types._metrics import MetricSpec
+from pymedphys._dvh._types._metrics import MetricSpec, OutputUnit
 from pymedphys._dvh._types._roi_ref import ROIRef
 from pymedphys._dvh._types._validators import (
     _validate_nonneg_array,
@@ -25,10 +25,6 @@ from pymedphys._dvh._types._validators import (
 
 _SUPPORTED_SCHEMA_VERSIONS = frozenset({"1.0"})
 
-_ISO8601_PATTERN = re.compile(
-    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
-)
-
 
 class ROIStatus(str, Enum):
     """Status of an ROI computation result."""
@@ -38,8 +34,9 @@ class ROIStatus(str, Enum):
     FAILED = "failed"
 
 
-# Valid unit families for MetricResult validation
-_VALID_METRIC_UNITS = frozenset({"Gy", "%Rx", "cc", "%vol", "dimensionless", ""})
+# Valid unit strings for MetricResult, derived from OutputUnit enum
+# plus "" for metrics where no unit applies (e.g. failed computations).
+_VALID_METRIC_UNITS = frozenset({u.value for u in OutputUnit} | {""})
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -575,12 +572,21 @@ class ProvenanceRecord:
     inapplicable_settings: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if self.timestamp_utc and not _ISO8601_PATTERN.match(self.timestamp_utc):
-            raise ValueError(
-                f"ProvenanceRecord.timestamp_utc must be a valid ISO 8601 "
-                f"timestamp (e.g. '2024-01-15T10:30:00Z'), "
-                f"got {self.timestamp_utc!r}"
-            )
+        if self.timestamp_utc:
+            try:
+                dt = datetime.fromisoformat(self.timestamp_utc)
+            except (ValueError, TypeError):
+                raise ValueError(
+                    f"ProvenanceRecord.timestamp_utc must be a valid ISO 8601 "
+                    f"timestamp (e.g. '2024-01-15T10:30:00Z'), "
+                    f"got {self.timestamp_utc!r}"
+                ) from None
+            if dt.tzinfo is None:
+                raise ValueError(
+                    f"ProvenanceRecord.timestamp_utc must include a timezone "
+                    f"designator (e.g. 'Z' or '+05:30'), "
+                    f"got {self.timestamp_utc!r}"
+                )
 
     def to_dict(self) -> dict:
         d: dict = {

--- a/lib/pymedphys/_dvh/_types/_results.py
+++ b/lib/pymedphys/_dvh/_types/_results.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import FrozenSet, Literal, Optional, get_args
 
 import numpy as np
@@ -17,8 +19,27 @@ from pymedphys._dvh._types._roi_ref import ROIRef
 from pymedphys._dvh._types._validators import (
     _validate_nonneg_array,
     _validate_nonneg_finite,
+    _validate_positive_finite,
     _validate_strictly_increasing,
 )
+
+_SUPPORTED_SCHEMA_VERSIONS = frozenset({"1.0"})
+
+_ISO8601_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+class ROIStatus(str, Enum):
+    """Status of an ROI computation result."""
+
+    OK = "ok"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+# Valid unit families for MetricResult validation
+_VALID_METRIC_UNITS = frozenset({"Gy", "%Rx", "cc", "%vol", "dimensionless", ""})
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -183,7 +204,13 @@ class DVHBins:
         )
 
     def __hash__(self) -> int:
-        return hash(self.dose_bin_edges_gy.tobytes())
+        return hash(
+            (
+                self.dose_bin_edges_gy.tobytes(),
+                self.differential_volume_cc.tobytes(),
+                float(self.total_volume_cc),
+            )
+        )
 
     def to_dict(self) -> dict:
         """Serialise to a plain dict. Cumulative values are NOT included."""
@@ -217,6 +244,22 @@ class MetricResult:
     unit: str
     convergence_estimate: Optional[float] = None
     issues: tuple[Issue, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.value is not None and not np.isfinite(self.value):
+            raise ValueError(f"MetricResult.value must be finite, got {self.value}")
+        if self.convergence_estimate is not None and not np.isfinite(
+            self.convergence_estimate
+        ):
+            raise ValueError(
+                f"MetricResult.convergence_estimate must be finite, "
+                f"got {self.convergence_estimate}"
+            )
+        if self.unit not in _VALID_METRIC_UNITS:
+            raise ValueError(
+                f"MetricResult.unit must be one of {sorted(_VALID_METRIC_UNITS)}, "
+                f"got {self.unit!r}"
+            )
 
     def to_dict(self) -> dict:
         d: dict = {
@@ -253,6 +296,53 @@ class ROIDiagnostics:
     endcap_volume_fraction: Optional[float] = None
     computation_time_s: Optional[float] = None
 
+    def __post_init__(self) -> None:
+        # Validate integer counts are non-negative
+        for name in (
+            "effective_supersampling",
+            "boundary_voxel_count",
+            "interior_voxel_count",
+        ):
+            val = getattr(self, name)
+            if val is not None:
+                if not isinstance(val, int) or val < 0:
+                    raise ValueError(
+                        f"ROIDiagnostics.{name} must be a non-negative "
+                        f"integer, got {val!r}"
+                    )
+
+        if self.contour_slice_count < 0:
+            raise ValueError(
+                f"ROIDiagnostics.contour_slice_count must be non-negative, "
+                f"got {self.contour_slice_count}"
+            )
+
+        # Validate finite non-negative floats
+        if self.mean_boundary_gradient_gy_per_mm is not None:
+            _validate_nonneg_finite(
+                self.mean_boundary_gradient_gy_per_mm,
+                "ROIDiagnostics.mean_boundary_gradient_gy_per_mm",
+            )
+
+        if self.computation_time_s is not None:
+            _validate_nonneg_finite(
+                self.computation_time_s,
+                "ROIDiagnostics.computation_time_s",
+            )
+
+        # Validate endcap_volume_fraction in [0, 1]
+        if self.endcap_volume_fraction is not None:
+            if not np.isfinite(self.endcap_volume_fraction):
+                raise ValueError(
+                    f"ROIDiagnostics.endcap_volume_fraction must be finite, "
+                    f"got {self.endcap_volume_fraction}"
+                )
+            if not 0.0 <= self.endcap_volume_fraction <= 1.0:
+                raise ValueError(
+                    f"ROIDiagnostics.endcap_volume_fraction must be in "
+                    f"[0, 1], got {self.endcap_volume_fraction}"
+                )
+
     def to_dict(self) -> dict:
         d: dict = {"contour_slice_count": self.contour_slice_count}
         for field_name in (
@@ -286,20 +376,38 @@ class ROIResult:
     """Complete result for a single ROI.
 
     Self-describing: carries its own ROIRef and explicit status.
+
+    The ``status`` field accepts both ``ROIStatus`` enum values and
+    plain strings (``"ok"``, ``"skipped"``, ``"failed"``), coercing
+    strings to enum values at construction time for backward
+    compatibility with serialised data.
     """
 
     roi: ROIRef
-    status: Literal["ok", "skipped", "failed"]
+    status: ROIStatus
     volume_cc: Optional[float] = None
     metrics: tuple[MetricResult, ...] = ()
     dvh: Optional[DVHBins] = None
     diagnostics: Optional[ROIDiagnostics] = None
     issues: tuple[Issue, ...] = ()
 
+    def __post_init__(self) -> None:
+        # Coerce string to ROIStatus enum for backward compatibility
+        if isinstance(self.status, str) and not isinstance(self.status, ROIStatus):
+            try:
+                object.__setattr__(self, "status", ROIStatus(self.status))
+            except ValueError:
+                raise ValueError(
+                    f"ROIResult.status must be one of "
+                    f"{[s.value for s in ROIStatus]}, got {self.status!r}"
+                ) from None
+
     def to_dict(self) -> dict:
         d: dict = {
             "roi": self.roi.to_dict(),
-            "status": self.status,
+            "status": self.status.value
+            if isinstance(self.status, ROIStatus)
+            else self.status,
         }
         if self.volume_cc is not None:
             d["volume_cc"] = self.volume_cc
@@ -466,6 +574,14 @@ class ProvenanceRecord:
     platform: Optional[PlatformInfo] = None
     inapplicable_settings: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        if self.timestamp_utc and not _ISO8601_PATTERN.match(self.timestamp_utc):
+            raise ValueError(
+                f"ProvenanceRecord.timestamp_utc must be a valid ISO 8601 "
+                f"timestamp (e.g. '2024-01-15T10:30:00Z'), "
+                f"got {self.timestamp_utc!r}"
+            )
+
     def to_dict(self) -> dict:
         d: dict = {
             "pymedphys_version": self.pymedphys_version,
@@ -510,6 +626,14 @@ class DVHResultSet:
     computation_time_s: float
     dose_refs: Optional[DoseReferenceSet] = None
     issues: tuple[Issue, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.schema_version not in _SUPPORTED_SCHEMA_VERSIONS:
+            raise ValueError(
+                f"Unsupported schema_version {self.schema_version!r}. "
+                f"Supported: {sorted(_SUPPORTED_SCHEMA_VERSIONS)}"
+            )
+        _validate_nonneg_finite(self.computation_time_s, "computation_time_s")
 
     def by_name(self, name: str) -> ROIResult:
         """Look up an ROIResult by name.

--- a/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
+++ b/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
@@ -31,9 +31,9 @@ class TestBenchmarkCaseRegistry:
     def test_cc_consistent_with_mm3(self) -> None:
         for case in BENCHMARK_CASES:
             expected_cc = mm3_to_cc(case.expected_volume_mm3)
-            assert case.expected_volume_cc == pytest.approx(expected_cc, rel=1e-12), (
-                f"Case {case.case_id}: cc mismatch"
-            )
+            assert case.expected_volume_cc == pytest.approx(
+                expected_cc, rel=1e-12
+            ), f"Case {case.case_id}: cc mismatch"
 
     def test_verify_registry_consistency_passes(self) -> None:
         """All registered cases must match their volume formulas."""

--- a/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
+++ b/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
@@ -31,9 +31,9 @@ class TestBenchmarkCaseRegistry:
     def test_cc_consistent_with_mm3(self) -> None:
         for case in BENCHMARK_CASES:
             expected_cc = mm3_to_cc(case.expected_volume_mm3)
-            assert case.expected_volume_cc == pytest.approx(
-                expected_cc, rel=1e-12
-            ), f"Case {case.case_id}: cc mismatch"
+            assert case.expected_volume_cc == pytest.approx(expected_cc, rel=1e-12), (
+                f"Case {case.case_id}: cc mismatch"
+            )
 
     def test_verify_registry_consistency_passes(self) -> None:
         """All registered cases must match their volume formulas."""
@@ -56,3 +56,9 @@ class TestBenchmarkCaseRegistry:
         case = BENCHMARK_CASES[0]
         with pytest.raises(AttributeError):
             case.case_id = "modified"  # type: ignore[misc]
+
+    def test_parameters_are_immutable(self) -> None:
+        """TEST-5: BenchmarkCase.parameters wrapped in MappingProxyType."""
+        case = BENCHMARK_CASES[0]
+        with pytest.raises(TypeError):
+            case.parameters["radius_mm"] = 999.0  # type: ignore[index]

--- a/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
+++ b/lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py
@@ -1,0 +1,58 @@
+"""Tests for the benchmark case registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from pymedphys._dvh._benchmarks import (
+    BENCHMARK_CASE_BY_ID,
+    BENCHMARK_CASES,
+    BenchmarkCase,
+    verify_registry_consistency,
+)
+from pymedphys._dvh._benchmarks._geometry import mm3_to_cc
+
+
+class TestBenchmarkCaseRegistry:
+    """Tests for the named benchmark case registry."""
+
+    def test_registry_is_non_empty(self) -> None:
+        assert len(BENCHMARK_CASES) > 0
+
+    def test_all_cases_have_unique_ids(self) -> None:
+        ids = [c.case_id for c in BENCHMARK_CASES]
+        assert len(ids) == len(set(ids))
+
+    def test_lookup_by_id_works(self) -> None:
+        case = BENCHMARK_CASE_BY_ID["sphere_r10"]
+        assert case.shape == "sphere"
+        assert case.parameters["radius_mm"] == 10.0
+
+    def test_cc_consistent_with_mm3(self) -> None:
+        for case in BENCHMARK_CASES:
+            expected_cc = mm3_to_cc(case.expected_volume_mm3)
+            assert case.expected_volume_cc == pytest.approx(expected_cc, rel=1e-12), (
+                f"Case {case.case_id}: cc mismatch"
+            )
+
+    def test_verify_registry_consistency_passes(self) -> None:
+        """All registered cases must match their volume formulas."""
+        verify_registry_consistency()
+
+    def test_all_shapes_have_cases(self) -> None:
+        shapes = {c.shape for c in BENCHMARK_CASES}
+        expected_shapes = {
+            "sphere",
+            "cylinder",
+            "cone",
+            "ellipsoid",
+            "torus",
+            "cylindrical_shell",
+            "rectangular_parallelepiped",
+        }
+        assert shapes == expected_shapes
+
+    def test_case_is_frozen(self) -> None:
+        case = BENCHMARK_CASES[0]
+        with pytest.raises(AttributeError):
+            case.case_id = "modified"  # type: ignore[misc]

--- a/lib/pymedphys/tests/dvh/test_serialisation.py
+++ b/lib/pymedphys/tests/dvh/test_serialisation.py
@@ -21,6 +21,7 @@ from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel
 from pymedphys._dvh._types._metrics import (
+    IndexMetric,
     MetricFamily,
     MetricRequestSet,
     MetricSpec,
@@ -158,6 +159,33 @@ class TestMetricSpecRoundTrip:
         restored = MetricSpec.from_dict(d)
         assert restored.family == MetricFamily.SCALAR
         assert restored.threshold is None
+
+    def test_index_metric_preserved(self) -> None:
+        """TEST-2: index_metric field survives round-trip."""
+        spec = MetricSpec(
+            family=MetricFamily.INDEX,
+            output_unit=OutputUnit.DIMENSIONLESS,
+            raw="CI",
+            index_metric=IndexMetric.CI,
+        )
+        d = spec.to_dict()
+        restored = MetricSpec.from_dict(d)
+        assert restored.index_metric == IndexMetric.CI
+        assert restored.family == MetricFamily.INDEX
+        assert restored.raw == "CI"
+
+    def test_dose_ref_id_preserved(self) -> None:
+        """TEST-3: dose_ref_id field survives round-trip."""
+        spec = MetricSpec(
+            family=MetricFamily.SCALAR,
+            output_unit=OutputUnit.GY,
+            raw="mean",
+            dose_ref_id="ptv42",
+        )
+        d = spec.to_dict()
+        assert d["dose_ref_id"] == "ptv42"
+        restored = MetricSpec.from_dict(d)
+        assert restored.dose_ref_id == "ptv42"
 
 
 class TestMetricRequestSetRoundTrip:

--- a/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
@@ -109,9 +109,51 @@ class TestIndexMetricParsing:
         )
         assert spec.requires_dose_ref is True
 
+    def test_implicit_index_metric_inference_from_raw(self) -> None:
+        """__post_init__ infers IndexMetric from raw when not explicitly set."""
+        spec = MetricSpec(
+            family=MetricFamily.INDEX,
+            output_unit=OutputUnit.DIMENSIONLESS,
+            raw="CI",
+        )
+        assert spec.index_metric == IndexMetric.CI
+        assert spec.requires_dose_ref is True
+
+    def test_implicit_hi_inference_does_not_require_dose_ref(self) -> None:
+        """HI inferred from raw should not require a dose ref."""
+        spec = MetricSpec(
+            family=MetricFamily.INDEX,
+            output_unit=OutputUnit.DIMENSIONLESS,
+            raw="HI",
+        )
+        assert spec.index_metric == IndexMetric.HI
+        assert spec.requires_dose_ref is False
+
 
 class TestPerMetricDoseRef:
     """Tests for per-metric dose_ref_id override."""
+
+    def test_metric_level_invalid_dose_ref_id_raises(self) -> None:
+        """MetricSpec with unknown dose_ref_id should raise ValueError."""
+        dose_refs = DoseReferenceSet(
+            refs={
+                "ptv60": DoseReference(60.0, "PTV60 prescription dose"),
+            },
+            default_id="ptv60",
+        )
+        spec = MetricSpec(
+            family=MetricFamily.INDEX,
+            output_unit=OutputUnit.DIMENSIONLESS,
+            raw="CI",
+            index_metric=IndexMetric.CI,
+            dose_ref_id="missing",
+        )
+        req = ROIMetricRequest(
+            roi=ROIRef(name="PTV"),
+            metrics=(spec,),
+        )
+        with pytest.raises(ValueError, match="missing.*not found"):
+            MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
 
     def test_metric_level_dose_ref_overrides_roi(self) -> None:
         """metric.dose_ref_id takes precedence over roi_request.dose_ref_id."""
@@ -313,11 +355,11 @@ class TestProvenanceTimestampValidation:
             ProvenanceRecord(timestamp_utc="not-a-timestamp")
 
     def test_rejects_date_only(self) -> None:
-        with pytest.raises(ValueError, match="ISO 8601"):
+        with pytest.raises(ValueError, match="timezone"):
             ProvenanceRecord(timestamp_utc="2024-01-15")
 
     def test_rejects_timestamp_without_timezone(self) -> None:
-        with pytest.raises(ValueError, match="ISO 8601"):
+        with pytest.raises(ValueError, match="timezone"):
             ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00")
 
 
@@ -356,7 +398,8 @@ class TestMetricResultValidation:
             MetricResult(spec=self._make_spec(), value=1.0, unit="invalid_unit")
 
     def test_accepts_valid_units(self) -> None:
-        for unit in ("Gy", "%Rx", "cc", "%vol", "dimensionless", ""):
+        # Valid units are derived from OutputUnit enum values plus ""
+        for unit in ("Gy", "percent_dose", "cc", "percent_vol", "dimensionless", ""):
             r = MetricResult(spec=self._make_spec(), value=1.0, unit=unit)
             assert r.unit == unit
 
@@ -452,6 +495,14 @@ class TestDoseReferenceSetImmutability:
                 10.0, "should not work"
             )
 
+    def test_rejects_empty_string_key(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            DoseReferenceSet(refs={"": DoseReference(60.0, "valid source text")})
+
+    def test_rejects_whitespace_only_key(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            DoseReferenceSet(refs={"   ": DoseReference(60.0, "valid source text")})
+
 
 # ── Item 5: GridFrame.from_dict() integer coercion ────────────────
 
@@ -486,6 +537,33 @@ class TestGridFrameFromDictIntegerCoercion:
         }
         gf = GridFrame.from_dict(d)
         assert gf.shape_zyx == (5, 5, 5)
+
+    def test_rejects_non_integer_shape(self) -> None:
+        """Non-integer shape values (e.g. 5.5) should be rejected, not truncated."""
+        d = {
+            "shape_zyx": [5.5, 10, 20],
+            "index_to_patient_mm": [
+                [0, 0, 1.0, 0],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+        }
+        with pytest.raises(ValueError, match="integers"):
+            GridFrame.from_dict(d)
+
+    def test_rejects_negative_shape_in_from_dict(self) -> None:
+        d = {
+            "shape_zyx": [-5, 10, 20],
+            "index_to_patient_mm": [
+                [0, 0, 1.0, 0],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+        }
+        with pytest.raises(ValueError, match="positive"):
+            GridFrame.from_dict(d)
 
 
 class TestGridFrameAxisPermutationPolicy:

--- a/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
@@ -675,3 +675,83 @@ class TestTorusValidityPolicy:
     def test_rejects_spindle_torus_R_less_than_r(self) -> None:
         with pytest.raises(ValueError, match="strictly greater"):
             torus_volume(5.0, 10.0)
+
+
+# ── Additional regression tests (review round 2) ─────────────────
+
+
+class TestIndexMetricCanonicalKeyDistinct:
+    """TEST-1: Multiple index metrics must coexist in same ROI."""
+
+    def test_hi_and_ci_have_different_canonical_keys(self) -> None:
+        hi = MetricSpec.parse("HI")
+        ci = MetricSpec.parse("CI")
+        assert hi.canonical_key != ci.canonical_key
+
+    def test_multiple_index_metrics_in_same_roi(self) -> None:
+        hi = MetricSpec.parse("HI")
+        ci = MetricSpec.parse("CI")
+        pci = MetricSpec.parse("PCI")
+        gi = MetricSpec.parse("GI")
+        dose_refs = DoseReferenceSet.single(60.0, "prescription: 30 fx x 2 Gy")
+        req = ROIMetricRequest(roi=ROIRef(name="PTV"), metrics=(hi, ci, pci, gi))
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        assert len(mrs.roi_requests[0].metrics) == 4
+
+
+class TestMeanAndMeanPercentRxCoexistence:
+    """TEST-4: mean and mean[%Rx] can coexist in same ROI."""
+
+    def test_mean_and_mean_percent_rx_different_canonical_keys(self) -> None:
+        m1 = MetricSpec.parse("mean")
+        m2 = MetricSpec.parse("mean[%Rx]")
+        assert m1.canonical_key != m2.canonical_key
+
+    def test_mean_and_mean_percent_rx_in_same_roi(self) -> None:
+        m1 = MetricSpec.parse("mean")
+        m2 = MetricSpec.parse("mean[%Rx]")
+        dose_refs = DoseReferenceSet.single(60.0, "prescription: 30 fx x 2 Gy")
+        req = ROIMetricRequest(roi=ROIRef(name="PTV"), metrics=(m1, m2))
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        assert len(mrs.roi_requests[0].metrics) == 2
+
+
+class TestROIDiagnosticsRejectsBool:
+    """TEST-7 + DESIGN-5: bool values rejected for integer count fields."""
+
+    def test_rejects_bool_boundary_voxel_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            ROIDiagnostics(boundary_voxel_count=True)
+
+    def test_rejects_bool_false_as_voxel_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            ROIDiagnostics(interior_voxel_count=False)
+
+
+class TestGridFrameFromDictZeroShape:
+    """TEST-7: GridFrame.from_dict rejects zero shape elements."""
+
+    def test_rejects_zero_shape_element(self) -> None:
+        d = {
+            "shape_zyx": [0, 10, 20],
+            "index_to_patient_mm": [
+                [0, 0, 1.0, 0],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+        }
+        with pytest.raises(ValueError, match="positive"):
+            GridFrame.from_dict(d)
+
+
+class TestUnknownIndexMetricRejected:
+    """DESIGN-2: Unknown index metric raw string is rejected."""
+
+    def test_rejects_unknown_index_metric(self) -> None:
+        with pytest.raises(ValueError, match="known index_metric"):
+            MetricSpec(
+                family=MetricFamily.INDEX,
+                output_unit=OutputUnit.DIMENSIONLESS,
+                raw="UNKNOWN_INDEX",
+            )

--- a/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py
@@ -1,0 +1,599 @@
+"""Regression tests for stacked type-system changes.
+
+Tests cover:
+- Item 1: Richer metric AST (IndexMetric, per-metric dose_ref_id, mean[%Rx])
+- Item 2: ROIStatus enum coercion, DVHResultSet validation, timestamp validation
+- Item 3: MetricResult and ROIDiagnostics validation
+- Item 4: DoseReference/DoseReferenceSet validation and immutability
+- Item 5: GridFrame.from_dict() integer coercion
+- Item 6: DVHBins.__hash__() value semantics
+- Item 7: Torus validity policy
+"""
+
+from __future__ import annotations
+
+import math
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from pymedphys._dvh._benchmarks._geometry import torus_volume
+from pymedphys._dvh._types._config import DVHConfig
+from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
+from pymedphys._dvh._types._grid_frame import GridFrame
+from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel
+from pymedphys._dvh._types._metrics import (
+    IndexMetric,
+    MetricFamily,
+    MetricRequestSet,
+    MetricSpec,
+    OutputUnit,
+    ROIMetricRequest,
+    ThresholdUnit,
+)
+from pymedphys._dvh._types._results import (
+    DVHBins,
+    DVHResultSet,
+    MetricResult,
+    ProvenanceRecord,
+    ROIDiagnostics,
+    ROIResult,
+    ROIStatus,
+)
+from pymedphys._dvh._types._roi_ref import ROIRef
+
+
+# ── Item 1: Richer metric AST ─────────────────────────────────────
+
+
+class TestIndexMetricEnum:
+    """Tests for the typed IndexMetric enum."""
+
+    def test_all_index_metrics_present(self) -> None:
+        assert set(IndexMetric) == {
+            IndexMetric.HI,
+            IndexMetric.CI,
+            IndexMetric.PCI,
+            IndexMetric.GI,
+        }
+
+    def test_hi_does_not_require_dose_ref(self) -> None:
+        assert IndexMetric.HI.requires_dose_ref is False
+
+    def test_ci_requires_dose_ref(self) -> None:
+        assert IndexMetric.CI.requires_dose_ref is True
+
+    def test_pci_requires_dose_ref(self) -> None:
+        assert IndexMetric.PCI.requires_dose_ref is True
+
+    def test_gi_requires_dose_ref(self) -> None:
+        assert IndexMetric.GI.requires_dose_ref is True
+
+
+class TestIndexMetricParsing:
+    """Tests for typed index metric construction via parse()."""
+
+    def test_parse_hi_sets_index_metric(self) -> None:
+        spec = MetricSpec.parse("HI")
+        assert spec.index_metric == IndexMetric.HI
+        assert spec.family == MetricFamily.INDEX
+
+    def test_parse_ci_sets_index_metric(self) -> None:
+        spec = MetricSpec.parse("CI")
+        assert spec.index_metric == IndexMetric.CI
+
+    def test_parse_pci_sets_index_metric(self) -> None:
+        spec = MetricSpec.parse("PCI")
+        assert spec.index_metric == IndexMetric.PCI
+
+    def test_parse_gi_sets_index_metric(self) -> None:
+        spec = MetricSpec.parse("GI")
+        assert spec.index_metric == IndexMetric.GI
+
+    def test_index_metric_round_trip_via_dict(self) -> None:
+        spec = MetricSpec.parse("CI")
+        d = spec.to_dict()
+        assert d["index_metric"] == "CI"
+        restored = MetricSpec.from_dict(d)
+        assert restored.index_metric == IndexMetric.CI
+        assert restored.family == MetricFamily.INDEX
+
+    def test_requires_dose_ref_uses_typed_enum(self) -> None:
+        """requires_dose_ref should use IndexMetric, not raw string."""
+        spec = MetricSpec(
+            family=MetricFamily.INDEX,
+            output_unit=OutputUnit.DIMENSIONLESS,
+            raw="CI",
+            index_metric=IndexMetric.CI,
+        )
+        assert spec.requires_dose_ref is True
+
+
+class TestPerMetricDoseRef:
+    """Tests for per-metric dose_ref_id override."""
+
+    def test_metric_level_dose_ref_overrides_roi(self) -> None:
+        """metric.dose_ref_id takes precedence over roi_request.dose_ref_id."""
+        dose_refs = DoseReferenceSet(
+            refs={
+                "ptv60": DoseReference(60.0, "PTV60 prescription dose"),
+                "ptv42": DoseReference(42.0, "PTV42 prescription dose"),
+            },
+            default_id="ptv60",
+        )
+        # Metric explicitly references ptv42, overriding ROI's ptv60
+        spec = MetricSpec(
+            family=MetricFamily.DVH_VOLUME,
+            threshold=95.0,
+            threshold_unit=ThresholdUnit.PERCENT,
+            output_unit=OutputUnit.CC,
+            raw="V95%",
+            dose_ref_id="ptv42",
+        )
+        req = ROIMetricRequest(
+            roi=ROIRef(name="PTV"),
+            metrics=(spec,),
+            dose_ref_id="ptv60",
+        )
+        # Should not raise — ptv42 exists in dose_refs
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        assert mrs.roi_requests[0].metrics[0].dose_ref_id == "ptv42"
+
+    def test_metric_dose_ref_id_serialises_round_trip(self) -> None:
+        spec = MetricSpec(
+            family=MetricFamily.SCALAR,
+            raw="mean",
+            dose_ref_id="ptv42",
+        )
+        d = spec.to_dict()
+        assert d["dose_ref_id"] == "ptv42"
+        restored = MetricSpec.from_dict(d)
+        assert restored.dose_ref_id == "ptv42"
+
+    def test_metric_dose_ref_id_absent_when_none(self) -> None:
+        spec = MetricSpec(family=MetricFamily.SCALAR, raw="mean")
+        d = spec.to_dict()
+        assert "dose_ref_id" not in d
+
+    def test_mixed_metrics_with_different_dose_refs(self) -> None:
+        """Mixed metrics within one ROI using different dose refs."""
+        dose_refs = DoseReferenceSet(
+            refs={
+                "ptv60": DoseReference(60.0, "PTV60 prescription dose"),
+                "ptv42": DoseReference(42.0, "PTV42 prescription dose"),
+            },
+            default_id="ptv60",
+        )
+        # First metric uses ptv42, second uses ROI-level default (ptv60)
+        spec1 = MetricSpec.parse("V95%")
+        object.__setattr__(spec1, "dose_ref_id", "ptv42")
+        spec2 = MetricSpec.parse("D95%[%Rx]")  # needs dose ref
+        req = ROIMetricRequest(
+            roi=ROIRef(name="PTV"),
+            metrics=(spec1, spec2),
+            dose_ref_id="ptv60",
+        )
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        assert len(mrs.roi_requests[0].metrics) == 2
+
+
+class TestMeanPercentRx:
+    """Tests for mean[%Rx] parsing and round-trip."""
+
+    def test_parse_mean_percent_rx(self) -> None:
+        spec = MetricSpec.parse("mean[%Rx]")
+        assert spec.family == MetricFamily.SCALAR
+        assert spec.output_unit == OutputUnit.PERCENT_DOSE
+
+    def test_mean_percent_rx_requires_dose_ref(self) -> None:
+        spec = MetricSpec.parse("mean[%Rx]")
+        assert spec.requires_dose_ref is True
+
+    def test_mean_percent_rx_round_trip(self) -> None:
+        spec = MetricSpec.parse("mean[%Rx]")
+        d = spec.to_dict()
+        restored = MetricSpec.from_dict(d)
+        assert restored.family == MetricFamily.SCALAR
+        assert restored.output_unit == OutputUnit.PERCENT_DOSE
+        assert restored.raw == "mean[%Rx]"
+
+
+# ── Item 2: ROIStatus enum, DVHResultSet validation, timestamps ───
+
+
+class TestROIStatusEnum:
+    """Tests for ROIStatus enum and string coercion."""
+
+    def test_valid_statuses(self) -> None:
+        assert ROIStatus.OK.value == "ok"
+        assert ROIStatus.SKIPPED.value == "skipped"
+        assert ROIStatus.FAILED.value == "failed"
+
+    def test_string_coercion_to_enum(self) -> None:
+        result = ROIResult(roi=ROIRef(name="PTV"), status="ok")
+        assert isinstance(result.status, ROIStatus)
+        assert result.status == ROIStatus.OK
+
+    def test_enum_value_accepted(self) -> None:
+        result = ROIResult(roi=ROIRef(name="PTV"), status=ROIStatus.SKIPPED)
+        assert result.status == ROIStatus.SKIPPED
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            ROIResult(roi=ROIRef(name="PTV"), status="invalid_status")
+
+    def test_status_serialises_as_string(self) -> None:
+        result = ROIResult(roi=ROIRef(name="PTV"), status=ROIStatus.OK)
+        d = result.to_dict()
+        assert d["status"] == "ok"
+
+    def test_status_deserialises_from_string(self) -> None:
+        d = {"roi": {"name": "PTV"}, "status": "failed"}
+        result = ROIResult.from_dict(d)
+        assert result.status == ROIStatus.FAILED
+
+
+class TestDVHResultSetValidation:
+    """Tests for DVHResultSet.__post_init__ validation."""
+
+    def _make_provenance(self) -> ProvenanceRecord:
+        return ProvenanceRecord(
+            pymedphys_version="0.1.0",
+            timestamp_utc="2024-01-01T00:00:00Z",
+        )
+
+    def test_rejects_unsupported_schema_version(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported schema_version"):
+            DVHResultSet(
+                schema_version="99.0",
+                results=(),
+                provenance=self._make_provenance(),
+                computation_time_s=1.0,
+            )
+
+    def test_accepts_supported_schema_version(self) -> None:
+        rs = DVHResultSet(
+            schema_version="1.0",
+            results=(),
+            provenance=self._make_provenance(),
+            computation_time_s=1.0,
+        )
+        assert rs.schema_version == "1.0"
+
+    def test_rejects_negative_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            DVHResultSet(
+                schema_version="1.0",
+                results=(),
+                provenance=self._make_provenance(),
+                computation_time_s=-1.0,
+            )
+
+    def test_rejects_nan_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DVHResultSet(
+                schema_version="1.0",
+                results=(),
+                provenance=self._make_provenance(),
+                computation_time_s=float("nan"),
+            )
+
+    def test_rejects_inf_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DVHResultSet(
+                schema_version="1.0",
+                results=(),
+                provenance=self._make_provenance(),
+                computation_time_s=float("inf"),
+            )
+
+
+class TestProvenanceTimestampValidation:
+    """Tests for ProvenanceRecord timestamp validation."""
+
+    def test_accepts_valid_iso8601_utc(self) -> None:
+        p = ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00Z")
+        assert p.timestamp_utc == "2024-01-15T10:30:00Z"
+
+    def test_accepts_valid_iso8601_with_offset(self) -> None:
+        p = ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00+05:30")
+        assert p.timestamp_utc == "2024-01-15T10:30:00+05:30"
+
+    def test_accepts_valid_iso8601_with_fractional_seconds(self) -> None:
+        p = ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00.123Z")
+        assert p.timestamp_utc == "2024-01-15T10:30:00.123Z"
+
+    def test_accepts_empty_string(self) -> None:
+        p = ProvenanceRecord(timestamp_utc="")
+        assert p.timestamp_utc == ""
+
+    def test_rejects_invalid_timestamp(self) -> None:
+        with pytest.raises(ValueError, match="ISO 8601"):
+            ProvenanceRecord(timestamp_utc="not-a-timestamp")
+
+    def test_rejects_date_only(self) -> None:
+        with pytest.raises(ValueError, match="ISO 8601"):
+            ProvenanceRecord(timestamp_utc="2024-01-15")
+
+    def test_rejects_timestamp_without_timezone(self) -> None:
+        with pytest.raises(ValueError, match="ISO 8601"):
+            ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00")
+
+
+# ── Item 3: MetricResult and ROIDiagnostics validation ────────────
+
+
+class TestMetricResultValidation:
+    """Tests for MetricResult.__post_init__ validation."""
+
+    def _make_spec(self) -> MetricSpec:
+        return MetricSpec(family=MetricFamily.SCALAR, raw="mean")
+
+    def test_rejects_nan_value(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            MetricResult(spec=self._make_spec(), value=float("nan"), unit="Gy")
+
+    def test_rejects_inf_value(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            MetricResult(spec=self._make_spec(), value=float("inf"), unit="Gy")
+
+    def test_accepts_none_value(self) -> None:
+        r = MetricResult(spec=self._make_spec(), value=None, unit="Gy")
+        assert r.value is None
+
+    def test_rejects_nan_convergence_estimate(self) -> None:
+        with pytest.raises(ValueError, match="convergence_estimate"):
+            MetricResult(
+                spec=self._make_spec(),
+                value=1.0,
+                unit="Gy",
+                convergence_estimate=float("nan"),
+            )
+
+    def test_rejects_invalid_unit(self) -> None:
+        with pytest.raises(ValueError, match="unit"):
+            MetricResult(spec=self._make_spec(), value=1.0, unit="invalid_unit")
+
+    def test_accepts_valid_units(self) -> None:
+        for unit in ("Gy", "%Rx", "cc", "%vol", "dimensionless", ""):
+            r = MetricResult(spec=self._make_spec(), value=1.0, unit=unit)
+            assert r.unit == unit
+
+
+class TestROIDiagnosticsValidation:
+    """Tests for ROIDiagnostics.__post_init__ validation."""
+
+    def test_rejects_negative_boundary_voxel_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            ROIDiagnostics(boundary_voxel_count=-1)
+
+    def test_rejects_negative_interior_voxel_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            ROIDiagnostics(interior_voxel_count=-5)
+
+    def test_rejects_negative_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ROIDiagnostics(computation_time_s=-0.1)
+
+    def test_rejects_nan_gradient(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            ROIDiagnostics(mean_boundary_gradient_gy_per_mm=float("nan"))
+
+    def test_rejects_endcap_fraction_above_one(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            ROIDiagnostics(endcap_volume_fraction=1.5)
+
+    def test_rejects_negative_endcap_fraction(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            ROIDiagnostics(endcap_volume_fraction=-0.1)
+
+    def test_accepts_valid_diagnostics(self) -> None:
+        diag = ROIDiagnostics(
+            effective_supersampling=3,
+            boundary_voxel_count=100,
+            interior_voxel_count=500,
+            mean_boundary_gradient_gy_per_mm=0.5,
+            contour_slice_count=10,
+            endcap_volume_fraction=0.02,
+            computation_time_s=1.5,
+        )
+        assert diag.effective_supersampling == 3
+        assert diag.endcap_volume_fraction == 0.02
+
+
+# ── Item 4: DoseReference/DoseReferenceSet validation ─────────────
+
+
+class TestDoseReferenceValidation:
+    """Tests for strengthened DoseReference validation."""
+
+    def test_rejects_nan_dose(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DoseReference(dose_gy=float("nan"), source="valid source text")
+
+    def test_rejects_inf_dose(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DoseReference(dose_gy=float("inf"), source="valid source text")
+
+    def test_rejects_neg_inf_dose(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DoseReference(dose_gy=float("-inf"), source="valid source text")
+
+    def test_rejects_source_without_alphabetic(self) -> None:
+        with pytest.raises(ValueError, match="alphabetic"):
+            DoseReference(dose_gy=60.0, source="12345")
+
+    def test_accepts_source_with_alpha(self) -> None:
+        ref = DoseReference(dose_gy=60.0, source="dose 60 Gy")
+        assert ref.source == "dose 60 Gy"
+
+
+class TestDoseReferenceSetImmutability:
+    """Tests for DoseReferenceSet immutability via MappingProxyType."""
+
+    def test_refs_is_mapping_proxy(self) -> None:
+        drs = DoseReferenceSet.single(42.0, "prescription: 3 fx x 14 Gy")
+        assert isinstance(drs.refs, MappingProxyType)
+
+    def test_caller_mutation_does_not_affect_stored_refs(self) -> None:
+        original = {"ptv60": DoseReference(60.0, "PTV60 prescription dose")}
+        drs = DoseReferenceSet(refs=original)
+        # Mutate the original dict
+        original["ptv42"] = DoseReference(42.0, "PTV42 prescription dose")
+        # DoseReferenceSet should not be affected
+        assert "ptv42" not in drs.refs
+        assert len(drs.refs) == 1
+
+    def test_stored_refs_cannot_be_mutated(self) -> None:
+        drs = DoseReferenceSet.single(42.0, "prescription: 3 fx x 14 Gy")
+        with pytest.raises(TypeError):
+            drs.refs["new_key"] = DoseReference(  # type: ignore[index]
+                10.0, "should not work"
+            )
+
+
+# ── Item 5: GridFrame.from_dict() integer coercion ────────────────
+
+
+class TestGridFrameFromDictIntegerCoercion:
+    """Tests for GridFrame.from_dict() integer coercion."""
+
+    def test_float_shape_coerced_to_int(self) -> None:
+        d = {
+            "shape_zyx": [10.0, 20.0, 30.0],
+            "index_to_patient_mm": [
+                [0, 0, 1.0, 0],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+        }
+        gf = GridFrame.from_dict(d)
+        assert gf.shape_zyx == (10, 20, 30)
+        assert all(isinstance(v, int) for v in gf.shape_zyx)
+
+    def test_string_shape_coerced_to_int(self) -> None:
+        """JSON may deserialise integers as strings in some contexts."""
+        d = {
+            "shape_zyx": ["5", "5", "5"],
+            "index_to_patient_mm": [
+                [0, 0, 1.0, 0],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+        }
+        gf = GridFrame.from_dict(d)
+        assert gf.shape_zyx == (5, 5, 5)
+
+
+class TestGridFrameAxisPermutationPolicy:
+    """Tests confirming axis permutation is allowed."""
+
+    def test_from_uniform_uses_permuted_affine(self) -> None:
+        gf = GridFrame.from_uniform(
+            shape_zyx=(5, 5, 5),
+            spacing_xyz_mm=(1.0, 2.0, 3.0),
+            origin_xyz_mm=(0.0, 0.0, 0.0),
+        )
+        # The affine has non-zero entries in permuted positions
+        assert gf.index_to_patient_mm[2, 0] != 0  # iz maps to z
+        assert gf.index_to_patient_mm[1, 1] != 0  # iy maps to y
+        assert gf.index_to_patient_mm[0, 2] != 0  # ix maps to x
+
+    def test_sign_flipped_affine_accepted(self) -> None:
+        aff = np.array(
+            [
+                [0, 0, -1.0, 10],
+                [0, 1.0, 0, 0],
+                [1.0, 0, 0, 0],
+                [0, 0, 0, 1],
+            ],
+            dtype=np.float64,
+        )
+        gf = GridFrame(shape_zyx=(5, 5, 5), index_to_patient_mm=aff)
+        assert gf.shape_zyx == (5, 5, 5)
+
+
+# ── Item 6: DVHBins.__hash__() value semantics ───────────────────
+
+
+class TestDVHBinsHashSemantics:
+    """Tests for DVHBins hash/equality consistency."""
+
+    def test_equal_objects_have_equal_hashes(self) -> None:
+        dvh1 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        dvh2 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        assert dvh1 == dvh2
+        assert hash(dvh1) == hash(dvh2)
+
+    def test_different_diff_volume_different_hash(self) -> None:
+        dvh1 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        dvh2 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([1.0, 4.0]),
+            total_volume_cc=5.0,
+        )
+        assert dvh1 != dvh2
+        # Hash collision is theoretically possible but extremely unlikely
+        assert hash(dvh1) != hash(dvh2)
+
+    def test_different_total_volume_different_hash(self) -> None:
+        dvh1 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        dvh2 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=10.0,
+        )
+        assert dvh1 != dvh2
+        assert hash(dvh1) != hash(dvh2)
+
+    def test_hashable_objects_work_in_set(self) -> None:
+        dvh1 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        dvh2 = DVHBins(
+            dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+            differential_volume_cc=np.array([3.0, 2.0]),
+            total_volume_cc=5.0,
+        )
+        assert len({dvh1, dvh2}) == 1
+
+
+# ── Item 7: Torus validity policy ────────────────────────────────
+
+
+class TestTorusValidityPolicy:
+    """Tests for simple torus restriction (R > r)."""
+
+    def test_valid_simple_torus(self) -> None:
+        v = torus_volume(20.0, 5.0)
+        expected = 2.0 * np.pi**2 * 20.0 * 25.0
+        assert v == pytest.approx(expected, rel=1e-12)
+
+    def test_rejects_horn_torus_R_equals_r(self) -> None:
+        with pytest.raises(ValueError, match="strictly greater"):
+            torus_volume(10.0, 10.0)
+
+    def test_rejects_spindle_torus_R_less_than_r(self) -> None:
+        with pytest.raises(ValueError, match="strictly greater"):
+            torus_volume(5.0, 10.0)


### PR DESCRIPTION
## Summary

This PR adds comprehensive regression tests for the DVH type system and strengthens validation across multiple type classes. It introduces a typed `IndexMetric` enum, per-metric dose reference overrides, enhanced validation for `MetricResult`, `ROIDiagnostics`, `DoseReference`, and `DVHResultSet`, immutability guarantees via `MappingProxyType`, and a named benchmark case registry for analytical volume validation.

## Why

The DVH type system has evolved significantly with richer metric AST support, stricter validation requirements, and new features like per-metric dose references. This PR:

1. **Prevents regressions** by establishing a comprehensive test suite covering all major type system changes
2. **Improves type safety** by replacing string-based index metric checks with a typed enum
3. **Strengthens data integrity** through validation of finite values, valid units, and proper ranges
4. **Ensures immutability** of dose reference sets to prevent accidental mutations
5. **Provides canonical benchmarks** for analytical volume validation across geometry shapes

## What changed

- **New test file** (`test_type_system_regression.py`): 599 lines of regression tests covering:
  - Item 1: Richer metric AST (IndexMetric enum, per-metric dose_ref_id, mean[%Rx])
  - Item 2: ROIStatus enum coercion, DVHResultSet validation, timestamp validation
  - Item 3: MetricResult and ROIDiagnostics validation
  - Item 4: DoseReference/DoseReferenceSet validation and immutability
  - Item 5: GridFrame.from_dict() integer coercion
  - Item 6: DVHBins.__hash__() value semantics
  - Item 7: Torus validity policy

- **New benchmark case registry** (`_cases.py`): Named analytical benchmark cases with expected volumes for canonical shapes (sphere, cylinder, cone, ellipsoid, torus, cylindrical shell, rectangular parallelepiped)

- **Type system enhancements**:
  - Added `IndexMetric` typed enum with `requires_dose_ref` property
  - Added `dose_ref_id` field to `MetricSpec` for per-metric dose reference overrides
  - Added `ROIStatus` enum with string coercion for backward compatibility
  - Enhanced `MetricResult.__post_init__()` to validate finite values and valid units
  - Enhanced `ROIDiagnostics.__post_init__()` to validate counts, ranges, and finite values
  - Enhanced `DoseReference.__post_init__()` to validate finite dose and alphabetic source
  - Enhanced `DoseReferenceSet` to use `MappingProxyType` for immutability
  - Enhanced `DVHResultSet.__post_init__()` to validate schema version and computation time
  - Enhanced `ProvenanceRecord` to validate ISO 8601 timestamps
  - Fixed `DVHBins.__hash__()` to include differential volume and total volume for value semantics
  - Enhanced `GridFrame.from_dict()` to coerce float/string shape values to integers
  - Strengthened `torus_volume()` to reject non-simple tori (R ≤ r)

- **Documentation improvements**: Updated docstrings to clarify validation rules and dose reference precedence

## How was this tested?

Added 599 lines of regression tests covering all seven items above. Tests verify:
- Enum parsing and round-trip serialization
- Validation of finite values, valid ranges, and proper types
- Immutability guarantees via MappingProxyType
- String coercion for backward compatibility
- Hash/equality consistency
- Benchmark case registry consistency

All tests are in `test_type_system_regression.py` and `test_cases.py`.

```bash
# Run regression tests
uv run pytest lib/pymedphys/tests/dvh/test_types/test_type_system_regression.py -v
uv run pytest lib/pymedphys/tests/dvh/test_benchmarks/test_cases.py -v
```

## Reviewer focus

- **Type safety**: The `IndexMetric` enum replaces string-based checks—verify the `requires

https://claude.ai/code/session_01XogfaM4dhv3V9LZHLMw9Sb

## Summary by Sourcery

Add DVH type-system validation and analytical benchmark registry, and introduce regression tests to lock in these behaviours.

New Features:
- Introduce an IndexMetric enum and per-metric dose reference overrides in MetricSpec, including support for mean[%Rx] metrics.
- Add ROIStatus enum with backward-compatible string coercion for ROIResult status values.
- Add a named analytical benchmark case registry with canonical geometric shapes and a consistency checker for expected volumes.

Bug Fixes:
- Ensure DVHBins hashing reflects dose bins, differential volume, and total volume so value-equal instances behave consistently in hash-based collections.
- Tighten torus_volume semantics to reject horn and spindle tori where the major radius is not strictly greater than the minor radius.

Enhancements:
- Strengthen validation across MetricResult, ROIDiagnostics, DoseReference, DoseReferenceSet, DVHResultSet, ProvenanceRecord, and GridFrame to enforce finite values, valid units, schema versions, ISO 8601 timestamps, affine constraints, and immutable dose-reference mappings.
- Clarify and enforce dose reference resolution precedence, allowing metric-level overrides ahead of ROI-level and global defaults.
- Document and formalise axis-aligned affine and dose reference semantics through updated docstrings.

Tests:
- Add comprehensive regression tests for DVH type-system behaviour, including metric parsing/AST, enums, validation paths, hashing semantics, grid frame coercion, and torus validity policy.
- Add tests for the benchmark case registry to verify uniqueness, shape coverage, unit consistency, and formula-based volume validation.