### PR TITLE
Phase 0: Lock down semantic contracts for DVH type layer

### DIFF
--- a/lib/pymedphys/_dvh/__init__.py
+++ b/lib/pymedphys/_dvh/__init__.py
@@ -1,14 +1,9 @@
-"""PyMedPhys DVH Calculator.
+"""PyMedPhys DVH Module — Phase 0: Type Layer.
 
-A transparent, configurable DVH calculator with analytical benchmarks
-and comprehensive validation.
+Provides typed domain objects, metric/request grammar, configuration,
+serialisation, and result containers for DVH computation.
 
-Public API
-----------
-compute_dvh : callable
-    Single entry point for DVH computation (not yet implemented).
-
-All domain types are available via ``pymedphys._dvh._types``.
+Computation entry points will be added in later phases.
 """
 
 from pymedphys._dvh._types import (

--- a/lib/pymedphys/_dvh/_serialisation.py
+++ b/lib/pymedphys/_dvh/_serialisation.py
@@ -1,10 +1,7 @@
-"""JSON/TOML serialisation for DVH types.
+"""JSON wrappers over per-type ``to_dict()`` / ``from_dict()`` methods.
 
-- **TOML** for human-edited inputs (metric requests, configuration).
-- **JSON** for machine-generated results (DVHResultSet output).
-
-Each serialisable type has its own ``to_dict()`` and ``from_dict()``
-methods. This module provides thin wrappers for JSON string conversion.
+TOML loading for metric requests is handled by
+``MetricRequestSet.from_toml()`` directly.
 """
 
 from __future__ import annotations

--- a/lib/pymedphys/_dvh/_types/_config.py
+++ b/lib/pymedphys/_dvh/_types/_config.py
@@ -6,6 +6,11 @@ import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 
+from pymedphys._dvh._types._validators import (
+    validate_nonneg_finite,
+    validate_positive_finite,
+)
+
 
 class InterpolationMethod(str, Enum):
     """Between-slice contour interpolation method."""
@@ -100,8 +105,9 @@ class SupersamplingConfig:
             raise ValueError(f"Supersampling factor must be >= 1, got {self.factor}")
         if self.adaptive_min_voxels < 1:
             raise ValueError("adaptive_min_voxels must be >= 1")
-        if self.adaptive_convergence_tol <= 0:
-            raise ValueError("adaptive_convergence_tol must be positive")
+        validate_positive_finite(
+            "adaptive_convergence_tol", self.adaptive_convergence_tol
+        )
 
     @classmethod
     def adaptive(
@@ -167,10 +173,7 @@ class AlgorithmConfig:
     floating_point_precision: FloatingPointPrecision = FloatingPointPrecision.FLOAT64
 
     def __post_init__(self) -> None:
-        if self.dvh_bin_width_gy <= 0:
-            raise ValueError(
-                f"dvh_bin_width_gy must be positive, got {self.dvh_bin_width_gy}"
-            )
+        validate_positive_finite("dvh_bin_width_gy", self.dvh_bin_width_gy)
         if (
             self.endcap_policy == EndCapPolicy.HALF_SLICE_CAPPED
             and self.endcap_max_mm is None
@@ -254,10 +257,7 @@ class RuntimeConfig:
     batch_size_gb: float = 12.0
 
     def __post_init__(self) -> None:
-        if self.batch_size_gb <= 0:
-            raise ValueError(
-                f"batch_size_gb must be positive, got {self.batch_size_gb}"
-            )
+        validate_positive_finite("batch_size_gb", self.batch_size_gb)
         if self.max_threads is not None and self.max_threads < 1:
             raise ValueError(f"max_threads must be >= 1, got {self.max_threads}")
 
@@ -288,6 +288,9 @@ class PipelinePolicy:
     invalid_roi_policy: InvalidROIPolicy = InvalidROIPolicy.REPAIR_IF_SAFE
     anonymise_provenance: bool = False
     z_tolerance_mm: float = 0.01
+
+    def __post_init__(self) -> None:
+        validate_nonneg_finite("z_tolerance_mm", self.z_tolerance_mm)
 
     def to_dict(self) -> dict:
         """Serialise to a plain dict."""

--- a/lib/pymedphys/_dvh/_types/_contour.py
+++ b/lib/pymedphys/_dvh/_types/_contour.py
@@ -1,4 +1,9 @@
-"""Geometry / structure types (RFC section 6.7)."""
+"""Geometry / structure types (RFC section 6.7).
+
+Validation covers structural correctness and orientation normalisation.
+Full geometric validation (self-intersection, repeated vertices, hole
+containment) is not yet implemented.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +14,7 @@ import numpy as np
 import numpy.typing as npt
 
 from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._validators import validate_finite_array
 
 
 class CombinationMode(str, Enum):
@@ -67,6 +73,7 @@ class Contour:
         if not np.isfinite(self.z_mm):
             raise ValueError(f"z_mm must be finite, got {self.z_mm}")
         pts = np.array(self.points_xy, dtype=np.float64)
+        validate_finite_array("Contour.points_xy", pts, ndim=2)
         pts.flags.writeable = False
         object.__setattr__(self, "points_xy", pts)
 
@@ -108,6 +115,7 @@ class PlanarRegion:
 
     def __post_init__(self) -> None:
         ext = np.array(self.exterior_xy_mm, dtype=np.float64)
+        validate_finite_array("PlanarRegion.exterior_xy_mm", ext, ndim=2)
         # D7: Validate exterior is CCW (positive signed area)
         ext_area = _signed_area(ext)
         if ext_area <= 0:
@@ -121,6 +129,7 @@ class PlanarRegion:
         validated_holes = []
         for i, h in enumerate(self.holes_xy_mm):
             hc = np.array(h, dtype=np.float64)
+            validate_finite_array(f"PlanarRegion.holes_xy_mm[{i}]", hc, ndim=2)
             # D7: Validate each hole is CW (negative signed area)
             hole_area = _signed_area(hc)
             if hole_area >= 0:

--- a/lib/pymedphys/_dvh/_types/_contour.py
+++ b/lib/pymedphys/_dvh/_types/_contour.py
@@ -188,6 +188,9 @@ class ContourROI:
     coordinate_frame: CoordinateFrame = CoordinateFrame.DICOM_PATIENT
 
     def __post_init__(self) -> None:
+        # Coerce list to tuple for true immutability
+        if isinstance(self.slices, list):
+            object.__setattr__(self, "slices", tuple(self.slices))
         # Coerce strings to enum for backward compatibility
         if isinstance(self.combination_mode, str):
             object.__setattr__(

--- a/lib/pymedphys/_dvh/_types/_dose.py
+++ b/lib/pymedphys/_dvh/_types/_dose.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.typing as npt
 
 from pymedphys._dvh._types._grid_frame import GridFrame
+from pymedphys._dvh._types._validators import validate_finite_array
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -38,12 +39,14 @@ class DoseGrid:
                 f"Dose shape {self.dose_gy.shape} != frame shape {expected}"
             )
         d = np.array(self.dose_gy, dtype=np.float64)
+        validate_finite_array("DoseGrid.dose_gy", d, ndim=3)
         d.flags.writeable = False
         object.__setattr__(self, "dose_gy", d)
         if self.uncertainty_gy is not None:
             if self.uncertainty_gy.shape != expected:
                 raise ValueError("Uncertainty shape must match dose shape")
             u = np.array(self.uncertainty_gy, dtype=np.float64)
+            validate_finite_array("DoseGrid.uncertainty_gy", u, ndim=3)
             u.flags.writeable = False
             object.__setattr__(self, "uncertainty_gy", u)
 

--- a/lib/pymedphys/_dvh/_types/_dose_ref.py
+++ b/lib/pymedphys/_dvh/_types/_dose_ref.py
@@ -66,8 +66,9 @@ class DoseReferenceSet:
 
     Parameters
     ----------
-    refs : dict[str, DoseReference]
-        Named dose references. Must be non-empty.
+    refs : Mapping[str, DoseReference]
+        Named dose references. Must be non-empty. Wrapped in
+        ``MappingProxyType`` at construction for true immutability.
     default_id : str, optional
         Key into ``refs`` for the default reference.
     """

--- a/lib/pymedphys/_dvh/_types/_dose_ref.py
+++ b/lib/pymedphys/_dvh/_types/_dose_ref.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+from pymedphys._dvh._types._validators import validate_positive_finite
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,8 +32,7 @@ class DoseReference:
     _SOURCE_RE = re.compile(r"[a-zA-Z]{3,}")
 
     def __post_init__(self) -> None:
-        if self.dose_gy <= 0:
-            raise ValueError(f"Reference dose must be positive, got {self.dose_gy}")
+        validate_positive_finite("DoseReference.dose_gy", self.dose_gy)
         stripped = self.source.strip()
         if not stripped:
             raise ValueError(
@@ -69,12 +72,12 @@ class DoseReferenceSet:
         Key into ``refs`` for the default reference.
     """
 
-    refs: dict[str, DoseReference]
+    refs: Mapping[str, DoseReference]
     default_id: str | None = None
 
     def __post_init__(self) -> None:
-        # Defensive copy to preserve immutability
-        object.__setattr__(self, "refs", dict(self.refs))
+        # Defensive copy wrapped in MappingProxyType for true immutability
+        object.__setattr__(self, "refs", MappingProxyType(dict(self.refs)))
         if not self.refs:
             raise ValueError("DoseReferenceSet must contain at least one reference")
         if self.default_id is not None and self.default_id not in self.refs:

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass
 import numpy as np
 import numpy.typing as npt
 
+from pymedphys._dvh._types._validators import validate_finite_array
+
 
 @dataclass(frozen=True, slots=True, eq=False)
 class GridFrame:
@@ -68,6 +70,7 @@ class GridFrame:
                 f"Affine must be (4, 4), got {self.index_to_patient_mm.shape}"
             )
         aff = np.array(self.index_to_patient_mm, dtype=np.float64)
+        validate_finite_array("index_to_patient_mm", aff)
 
         # Validate bottom row is [0, 0, 0, 1]
         if not np.allclose(aff[3, :], [0, 0, 0, 1]):
@@ -84,10 +87,15 @@ class GridFrame:
                 f"(dz={col_norms[0]}, dy={col_norms[1]}, dx={col_norms[2]})"
             )
 
-        # Validate axis-aligned: the 3x3 rotation sub-matrix must have
-        # exactly one non-zero entry per row and per column.
+        # Validate axis-aligned with fixed semantic mapping:
+        #   column 0 (iz) -> patient z (row 2)
+        #   column 1 (iy) -> patient y (row 1)
+        #   column 2 (ix) -> patient x (row 0)
+        # Sign flips are allowed; axis permutation is not.
         rot = aff[:3, :3]
         mask = np.abs(rot) > 1e-12
+
+        # First check basic axis-alignment: one nonzero per row/column
         for i in range(3):
             if np.count_nonzero(mask[i, :]) != 1:
                 raise ValueError(
@@ -100,6 +108,24 @@ class GridFrame:
                     "Only axis-aligned grids are currently supported. "
                     f"Column {i} of the affine rotation sub-matrix has "
                     f"multiple non-zero entries: {rot[:, i]}"
+                )
+
+        # Enforce fixed axis semantics (no permutation):
+        # col 0 (iz step) must have its nonzero in row 2 (patient z)
+        # col 1 (iy step) must have its nonzero in row 1 (patient y)
+        # col 2 (ix step) must have its nonzero in row 0 (patient x)
+        expected_rows = {0: 2, 1: 1, 2: 0}  # col -> expected row
+        for col, expected_row in expected_rows.items():
+            nonzero_row = int(np.argmax(mask[:, col]))
+            if nonzero_row != expected_row:
+                axis_names = {0: "z", 1: "y", 2: "x"}
+                idx_names = {0: "iz", 1: "iy", 2: "ix"}
+                raise ValueError(
+                    f"Axis permutation not allowed: column {col} "
+                    f"({idx_names[col]}) must map to patient "
+                    f"{axis_names[expected_row]}, but maps to patient "
+                    f"{axis_names[nonzero_row]}. "
+                    f"Use from_uniform() to construct standard grids."
                 )
 
         aff.flags.writeable = False

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -118,7 +118,7 @@ class GridFrame:
         for col, expected_row in expected_rows.items():
             nonzero_row = int(np.argmax(mask[:, col]))
             if nonzero_row != expected_row:
-                axis_names = {0: "z", 1: "y", 2: "x"}
+                axis_names = {0: "x", 1: "y", 2: "z"}
                 idx_names = {0: "iz", 1: "iy", 2: "ix"}
                 raise ValueError(
                     f"Axis permutation not allowed: column {col} "

--- a/lib/pymedphys/_dvh/_types/_grid_frame.py
+++ b/lib/pymedphys/_dvh/_types/_grid_frame.py
@@ -116,6 +116,7 @@ class GridFrame:
         # col 2 (ix step) must have its nonzero in row 0 (patient x)
         expected_rows = {0: 2, 1: 1, 2: 0}  # col -> expected row
         for col, expected_row in expected_rows.items():
+            # Safe: prior loop guarantees exactly one True per column
             nonzero_row = int(np.argmax(mask[:, col]))
             if nonzero_row != expected_row:
                 axis_names = {0: "x", 1: "y", 2: "z"}

--- a/lib/pymedphys/_dvh/_types/_inputs.py
+++ b/lib/pymedphys/_dvh/_types/_inputs.py
@@ -31,3 +31,7 @@ class DVHInputs:
     structures: tuple[ContourROI, ...]
     rtstruct_path: str | None = None
     rtdose_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.structures, list):
+            object.__setattr__(self, "structures", tuple(self.structures))

--- a/lib/pymedphys/_dvh/_types/_inputs.py
+++ b/lib/pymedphys/_dvh/_types/_inputs.py
@@ -4,19 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import numpy.typing as npt
-
 from pymedphys._dvh._types._contour import ContourROI
 from pymedphys._dvh._types._dose import DoseGrid
-from pymedphys._dvh._types._grid_frame import GridFrame
 
 
 @dataclass(frozen=True, slots=True)
 class DVHInputs:
     """Typed input bundle for DVH computation.
 
-    Use the named constructors to build inputs from DICOM paths
-    or raw NumPy arrays.
+    Construction from DICOM files or raw arrays will be added in a
+    later phase. For now, build instances directly.
 
     Parameters
     ----------
@@ -34,38 +31,3 @@ class DVHInputs:
     structures: tuple[ContourROI, ...]
     rtstruct_path: str | None = None
     rtdose_path: str | None = None
-
-    @classmethod
-    def from_dicom(
-        cls,
-        rtstruct_path: str,
-        rtdose_path: str,
-        roi_names: list[str] | None = None,
-        # TODO (Phase 4): policy should be PipelinePolicy, not object
-        policy: object | None = None,
-    ) -> DVHInputs:
-        """Load from DICOM RTSTRUCT + RTDOSE files.
-
-        Not yet implemented — requires Phase 4.
-        """
-        raise NotImplementedError(
-            "DVHInputs.from_dicom() is not yet implemented (Phase 4)"
-        )
-
-    @classmethod
-    def from_arrays(
-        cls,
-        # TODO (Phase 4): dose_gy should be npt.NDArray[np.float64]
-        dose_gy: npt.ArrayLike,
-        # TODO (Phase 4): structures should be dict[str, ContourROI]
-        structures: dict[str, object],
-        # TODO (Phase 4): frame should be GridFrame
-        frame: GridFrame | object,
-    ) -> DVHInputs:
-        """Build from raw NumPy arrays.
-
-        Not yet implemented — requires Phase 4.
-        """
-        raise NotImplementedError(
-            "DVHInputs.from_arrays() is not yet implemented (Phase 4)"
-        )

--- a/lib/pymedphys/_dvh/_types/_issues.py
+++ b/lib/pymedphys/_dvh/_types/_issues.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from types import MappingProxyType
+from typing import Any, Mapping
 
 
 class IssueLevel(str, Enum):
@@ -57,7 +58,11 @@ class Issue:
     code: IssueCode
     message: str
     path: tuple[str, ...] = ()
-    context: dict[str, Any] | None = None
+    context: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.context is not None:
+            object.__setattr__(self, "context", MappingProxyType(dict(self.context)))
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a plain dict."""
@@ -69,7 +74,7 @@ class Issue:
         if self.path:
             d["path"] = list(self.path)
         if self.context is not None:
-            d["context"] = self.context
+            d["context"] = dict(self.context)
         return d
 
     @classmethod

--- a/lib/pymedphys/_dvh/_types/_metrics.py
+++ b/lib/pymedphys/_dvh/_types/_metrics.py
@@ -334,6 +334,9 @@ class ROIMetricRequest:
     dose_ref_id: str | None = None
 
     def __post_init__(self) -> None:
+        # Coerce list to tuple for true immutability
+        if isinstance(self.metrics, list):
+            object.__setattr__(self, "metrics", tuple(self.metrics))
         if not self.metrics:
             raise ValueError(f"ROI '{self.roi}' must have at least one metric")
         keys = [m.canonical_key for m in self.metrics]
@@ -391,22 +394,17 @@ class MetricRequestSet:
     dose_refs: DoseReferenceSet | None = None
 
     def __post_init__(self) -> None:
-        # F2: Set-based duplicate ROI detection for O(n) average case.
-        # We check by name (for ROIs without numbers) and by number
-        # (for ROIs with numbers) separately.
-        seen_names: set[str] = set()
-        seen_numbers: set[int] = set()
-        for rr in self.roi_requests:
-            if rr.roi.roi_number is not None:
-                if rr.roi.roi_number in seen_numbers:
+        # Coerce list to tuple for true immutability
+        if isinstance(self.roi_requests, list):
+            object.__setattr__(self, "roi_requests", tuple(self.roi_requests))
+        # Duplicate ROI detection using ROIRef.matches() semantics:
+        # match by roi_number if both have one, otherwise by name.
+        for i, a in enumerate(self.roi_requests):
+            for b in self.roi_requests[i + 1 :]:
+                if a.roi.matches(b.roi):
                     raise ValueError(
-                        f"Duplicate ROI in request: roi_number={rr.roi.roi_number}"
+                        f"Duplicate ROI in request: '{a.roi}' and '{b.roi}'"
                     )
-                seen_numbers.add(rr.roi.roi_number)
-            else:
-                if rr.roi.name in seen_names:
-                    raise ValueError(f"Duplicate ROI in request: '{rr.roi.name}'")
-                seen_names.add(rr.roi.name)
         for rr in self.roi_requests:
             for m in rr.metrics:
                 if m.requires_dose_ref:
@@ -424,31 +422,29 @@ class MetricRequestSet:
                             f"Metric '{m.raw}' for ROI '{rr.roi}': {e}"
                         ) from e
 
-    def to_dict(self) -> dict:
-        """Serialise to a dict compatible with ``from_dict()``.
+    @property
+    def default_dose_ref(self) -> str | None:
+        """Default dose reference id, if any."""
+        if self.dose_refs is None:
+            return None
+        return self.dose_refs.default_id
 
-        Uses the rich format with explicit dose_refs and per-ROI
-        metric dicts.
+    def to_dict(self) -> dict:
+        """Serialise to a lossless canonical dict.
+
+        The canonical format uses ``roi_requests`` — a list of explicit
+        ``ROIMetricRequest.to_dict()`` entries — so that duplicate ROI
+        names, per-metric metadata, and per-ROI dose_ref_ids are all
+        preserved without loss.
+
+        The legacy ``metrics`` name-keyed format is accepted only as an
+        input convenience in ``from_dict()``.
         """
-        d: dict = {}
-        if self.dose_refs is not None:
-            d["dose_refs"] = {
-                k: {"dose_gy": v.dose_gy, "source": v.source}
-                for k, v in self.dose_refs.refs.items()
-            }
-            if self.dose_refs.default_id is not None:
-                d["default_dose_ref"] = self.dose_refs.default_id
-        metrics: dict = {}
-        for rr in self.roi_requests:
-            entry: dict = {
-                "metrics": [m.raw for m in rr.metrics],
-            }
-            if rr.roi.roi_number is not None:
-                entry["roi_number"] = rr.roi.roi_number
-            if rr.dose_ref_id is not None:
-                entry["dose_ref"] = rr.dose_ref_id
-            metrics[rr.roi.name] = entry
-        d["metrics"] = metrics
+        d: dict = {
+            "dose_refs": self.dose_refs.to_dict() if self.dose_refs else None,
+            "default_dose_ref": self.default_dose_ref,
+            "roi_requests": [rr.to_dict() for rr in self.roi_requests],
+        }
         return d
 
     @property
@@ -458,20 +454,33 @@ class MetricRequestSet:
 
     @classmethod
     def from_dict(cls, d: dict) -> MetricRequestSet:
-        """Construct from a compact dict representation.
+        """Construct from a dict representation.
 
-        Supports both simple (single dose ref) and rich (SIB) formats.
-        See RFC section 6.5 for full schema.
+        Accepts two formats:
+
+        **Canonical** (lossless, emitted by ``to_dict()``):
+            ``{"dose_refs": ..., "default_dose_ref": ..., "roi_requests": [...]}``
+
+        **Legacy/compact** (for hand-authored TOML or backwards compat):
+            ``{"metrics": {roi_name: [metric_strings] | {metrics: [...], ...}}, ...}``
+            with optional ``dose_refs``, ``dose_ref_gy``, ``dose_ref_source``.
         """
+        # --- Dose references ---
         dose_refs = None
-        if "dose_refs" in d:
-            refs = {
-                k: DoseReference(dose_gy=v["dose_gy"], source=v["source"])
-                for k, v in d["dose_refs"].items()
-            }
-            dose_refs = DoseReferenceSet(
-                refs=refs, default_id=d.get("default_dose_ref")
-            )
+        dose_refs_raw = d.get("dose_refs")
+        if dose_refs_raw is not None:
+            # Canonical format: dose_refs is a DoseReferenceSet.to_dict()
+            if "refs" in dose_refs_raw:
+                dose_refs = DoseReferenceSet.from_dict(dose_refs_raw)
+            else:
+                # Legacy format: dose_refs is {id: {dose_gy, source}}
+                refs = {
+                    k: DoseReference(dose_gy=v["dose_gy"], source=v["source"])
+                    for k, v in dose_refs_raw.items()
+                }
+                dose_refs = DoseReferenceSet(
+                    refs=refs, default_id=d.get("default_dose_ref")
+                )
         elif "dose_ref_gy" in d:
             source = d.get("dose_ref_source")
             if not source or not source.strip():
@@ -480,21 +489,36 @@ class MetricRequestSet:
                 )
             dose_refs = DoseReferenceSet.single(dose_gy=d["dose_ref_gy"], source=source)
 
-        roi_requests = []
-        for roi_key, spec in d["metrics"].items():
-            if isinstance(spec, list):
-                roi_requests.append(ROIMetricRequest.from_strings(roi_key, spec))
-            elif isinstance(spec, dict):
-                roi_requests.append(
-                    ROIMetricRequest.from_strings(
-                        roi_key,
-                        spec["metrics"],
-                        roi_number=spec.get("roi_number"),
-                        dose_ref_id=spec.get("dose_ref"),
+        # --- ROI requests ---
+        if "roi_requests" in d:
+            # Canonical format
+            roi_requests = tuple(
+                ROIMetricRequest.from_dict(rr) for rr in d["roi_requests"]
+            )
+        elif "metrics" in d:
+            # Legacy compact format
+            roi_list: list[ROIMetricRequest] = []
+            for roi_key, spec in d["metrics"].items():
+                if isinstance(spec, list):
+                    roi_list.append(ROIMetricRequest.from_strings(roi_key, spec))
+                elif isinstance(spec, dict):
+                    roi_list.append(
+                        ROIMetricRequest.from_strings(
+                            roi_key,
+                            spec["metrics"],
+                            roi_number=spec.get("roi_number"),
+                            dose_ref_id=spec.get("dose_ref"),
+                        )
                     )
-                )
+            roi_requests = tuple(roi_list)
+        else:
+            raise ValueError(
+                "MetricRequestSet.from_dict() requires either 'roi_requests' "
+                "(canonical) or 'metrics' (legacy) key"
+            )
+
         return cls(
-            roi_requests=tuple(roi_requests),
+            roi_requests=roi_requests,
             dose_refs=dose_refs,
         )
 

--- a/lib/pymedphys/_dvh/_types/_metrics.py
+++ b/lib/pymedphys/_dvh/_types/_metrics.py
@@ -21,6 +21,7 @@ from enum import Enum
 
 from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
 from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._validators import validate_nonneg_finite
 
 
 class MetricFamily(str, Enum):
@@ -126,10 +127,8 @@ class MetricSpec:
     raw: str = ""
 
     def __post_init__(self) -> None:
-        if self.threshold is not None and self.threshold < 0:
-            raise ValueError(
-                f"Metric threshold must be non-negative, got {self.threshold}"
-            )
+        if self.threshold is not None:
+            validate_nonneg_finite("MetricSpec.threshold", self.threshold)
         if self.family == MetricFamily.INDEX and self.index_metric is None:
             # Auto-derive from raw for backward compatibility
             if self.raw in {m.value for m in IndexMetric}:
@@ -400,14 +399,15 @@ class MetricRequestSet:
         # Duplicate ROI detection using ROIRef.matches() semantics:
         # match by roi_number if both have one, otherwise by name.
         #
-        # Set-based O(n) approach with three buckets:
-        #   seen_numbers: numbered ROIs keyed by roi_number
-        #   seen_unnumbered_names: unnumbered ROIs keyed by name
-        #   seen_numbered_names: names claimed by numbered ROIs
-        #
-        # matches() logic:
-        #   Both numbered → compare numbers (same name, different number = OK)
-        #   One or both unnumbered → compare names
+        # O(n) set-based approach — provably equivalent to pairwise
+        # matches() for all (A, B) pairs:
+        #   Case 1: both numbered → collision iff same number →
+        #           caught by seen_numbers.
+        #   Case 2: both unnumbered → collision iff same name →
+        #           caught by seen_unnumbered_names.
+        #   Case 3: one numbered, one not → collision iff same name →
+        #           caught by cross-checks between seen_numbered_names
+        #           and seen_unnumbered_names.
         seen_numbers: dict[int, ROIRef] = {}
         seen_unnumbered_names: dict[str, ROIRef] = {}
         seen_numbered_names: dict[str, ROIRef] = {}
@@ -482,8 +482,6 @@ class MetricRequestSet:
         }
         if self.dose_refs is not None:
             d["dose_refs"] = self.dose_refs.to_dict()
-        if self.default_dose_ref is not None:
-            d["default_dose_ref"] = self.default_dose_ref
         return d
 
     @property
@@ -509,7 +507,11 @@ class MetricRequestSet:
         dose_refs_raw = d.get("dose_refs")
         if dose_refs_raw is not None:
             # Canonical format: dose_refs is a DoseReferenceSet.to_dict()
-            if "refs" in dose_refs_raw:
+            # which has {"refs": {id: {...}, ...}, "default_id": ...}.
+            # Legacy format has {id: {"dose_gy": ..., "source": ...}}.
+            # Distinguish by checking whether "refs" maps to a dict of
+            # dicts (canonical) vs a flat value dict (legacy ID named "refs").
+            if "refs" in dose_refs_raw and isinstance(dose_refs_raw["refs"], dict):
                 dose_refs = DoseReferenceSet.from_dict(dose_refs_raw)
             else:
                 # Legacy format: dose_refs is {id: {dose_gy, source}}

--- a/lib/pymedphys/_dvh/_types/_metrics.py
+++ b/lib/pymedphys/_dvh/_types/_metrics.py
@@ -399,12 +399,49 @@ class MetricRequestSet:
             object.__setattr__(self, "roi_requests", tuple(self.roi_requests))
         # Duplicate ROI detection using ROIRef.matches() semantics:
         # match by roi_number if both have one, otherwise by name.
-        for i, a in enumerate(self.roi_requests):
-            for b in self.roi_requests[i + 1 :]:
-                if a.roi.matches(b.roi):
+        #
+        # Set-based O(n) approach with three buckets:
+        #   seen_numbers: numbered ROIs keyed by roi_number
+        #   seen_unnumbered_names: unnumbered ROIs keyed by name
+        #   seen_numbered_names: names claimed by numbered ROIs
+        #
+        # matches() logic:
+        #   Both numbered → compare numbers (same name, different number = OK)
+        #   One or both unnumbered → compare names
+        seen_numbers: dict[int, ROIRef] = {}
+        seen_unnumbered_names: dict[str, ROIRef] = {}
+        seen_numbered_names: dict[str, ROIRef] = {}
+        for rr in self.roi_requests:
+            ref = rr.roi
+            if ref.roi_number is not None:
+                # Check against other numbered ROIs by number
+                if ref.roi_number in seen_numbers:
                     raise ValueError(
-                        f"Duplicate ROI in request: '{a.roi}' and '{b.roi}'"
+                        f"Duplicate ROI in request: '{ref}' and "
+                        f"'{seen_numbers[ref.roi_number]}'"
                     )
+                # Check against unnumbered ROIs by name (mixed case)
+                if ref.name in seen_unnumbered_names:
+                    raise ValueError(
+                        f"Duplicate ROI in request: '{ref}' and "
+                        f"'{seen_unnumbered_names[ref.name]}'"
+                    )
+                seen_numbers[ref.roi_number] = ref
+                seen_numbered_names[ref.name] = ref
+            else:
+                # Check against other unnumbered ROIs by name
+                if ref.name in seen_unnumbered_names:
+                    raise ValueError(
+                        f"Duplicate ROI in request: '{ref}' and "
+                        f"'{seen_unnumbered_names[ref.name]}'"
+                    )
+                # Check against numbered ROIs by name (mixed case)
+                if ref.name in seen_numbered_names:
+                    raise ValueError(
+                        f"Duplicate ROI in request: '{ref}' and "
+                        f"'{seen_numbered_names[ref.name]}'"
+                    )
+                seen_unnumbered_names[ref.name] = ref
         for rr in self.roi_requests:
             for m in rr.metrics:
                 if m.requires_dose_ref:
@@ -441,10 +478,12 @@ class MetricRequestSet:
         input convenience in ``from_dict()``.
         """
         d: dict = {
-            "dose_refs": self.dose_refs.to_dict() if self.dose_refs else None,
-            "default_dose_ref": self.default_dose_ref,
             "roi_requests": [rr.to_dict() for rr in self.roi_requests],
         }
+        if self.dose_refs is not None:
+            d["dose_refs"] = self.dose_refs.to_dict()
+        if self.default_dose_ref is not None:
+            d["default_dose_ref"] = self.default_dose_ref
         return d
 
     @property

--- a/lib/pymedphys/_dvh/_types/_occupancy.py
+++ b/lib/pymedphys/_dvh/_types/_occupancy.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._validators import validate_finite_array
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -39,6 +40,7 @@ class OccupancyField:
                 f"Occupancy shape {self.data.shape} != frame shape {expected}"
             )
         d = np.array(self.data, dtype=np.float64)
+        validate_finite_array("OccupancyField.data", d)
         if np.any((d < 0.0) | (d > 1.0)):
             raise ValueError(
                 "Occupancy values must be in [0.0, 1.0], "

--- a/lib/pymedphys/_dvh/_types/_results.py
+++ b/lib/pymedphys/_dvh/_types/_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -13,8 +14,15 @@ from pymedphys._dvh._types._config import DVHConfig
 from pymedphys._dvh._types._dose_ref import DoseReferenceSet
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._issues import Issue
-from pymedphys._dvh._types._metrics import MetricSpec
+from pymedphys._dvh._types._metrics import MetricSpec, OutputUnit
 from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._validators import (
+    validate_finite,
+    validate_finite_array,
+    validate_in_range,
+    validate_nonneg_finite,
+    validate_positive_finite,
+)
 
 
 class ROIStatus(str, Enum):
@@ -55,6 +63,9 @@ class DVHBins:
     def __post_init__(self) -> None:
         edges = np.array(self.dose_bin_edges_gy, dtype=np.float64)
         dv = np.array(self.differential_volume_cc, dtype=np.float64)
+        validate_finite_array("dose_bin_edges_gy", edges, ndim=1)
+        validate_finite_array("differential_volume_cc", dv, ndim=1)
+        validate_positive_finite("total_volume_cc", self.total_volume_cc)
         if len(edges) < 2:
             raise ValueError("DVHBins needs at least 2 bin edges (1 bin)")
         if len(dv) != len(edges) - 1:
@@ -76,11 +87,6 @@ class DVHBins:
         # A1: Differential volumes must be non-negative
         if np.any(dv < 0):
             raise ValueError("differential_volume_cc values must be non-negative")
-        # A1: Total volume must be strictly positive
-        if self.total_volume_cc <= 0:
-            raise ValueError(
-                f"total_volume_cc must be strictly positive, got {self.total_volume_cc}"
-            )
         # A4: Sum of differential volumes must not exceed total volume
         dv_sum = float(np.sum(dv))
         if dv_sum > self.total_volume_cc * (1.0 + 1e-9):
@@ -181,6 +187,9 @@ class DVHBins:
         )
 
 
+_VALID_UNITS = frozenset(u.value for u in OutputUnit)
+
+
 @dataclass(frozen=True, slots=True)
 class MetricResult:
     """Result for a single computed metric.
@@ -193,6 +202,22 @@ class MetricResult:
     unit: str
     convergence_estimate: float | None = None
     issues: tuple[Issue, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Coerce list to tuple
+        if isinstance(self.issues, list):
+            object.__setattr__(self, "issues", tuple(self.issues))
+        if self.value is not None:
+            validate_finite("MetricResult.value", self.value)
+        if self.convergence_estimate is not None:
+            validate_nonneg_finite(
+                "MetricResult.convergence_estimate", self.convergence_estimate
+            )
+        if self.unit not in _VALID_UNITS:
+            raise ValueError(
+                f"MetricResult.unit must be one of {sorted(_VALID_UNITS)}, "
+                f"got {self.unit!r}"
+            )
 
     def to_dict(self) -> dict:
         d: dict = {
@@ -228,6 +253,42 @@ class ROIDiagnostics:
     contour_slice_count: int = 0
     endcap_volume_fraction: float | None = None
     computation_time_s: float | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.effective_supersampling is not None
+            and self.effective_supersampling < 1
+        ):
+            raise ValueError(
+                f"effective_supersampling must be >= 1, "
+                f"got {self.effective_supersampling}"
+            )
+        if self.boundary_voxel_count is not None and self.boundary_voxel_count < 0:
+            raise ValueError(
+                f"boundary_voxel_count must be non-negative, "
+                f"got {self.boundary_voxel_count}"
+            )
+        if self.interior_voxel_count is not None and self.interior_voxel_count < 0:
+            raise ValueError(
+                f"interior_voxel_count must be non-negative, "
+                f"got {self.interior_voxel_count}"
+            )
+        if self.mean_boundary_gradient_gy_per_mm is not None:
+            validate_nonneg_finite(
+                "mean_boundary_gradient_gy_per_mm",
+                self.mean_boundary_gradient_gy_per_mm,
+            )
+        if self.contour_slice_count < 0:
+            raise ValueError(
+                f"contour_slice_count must be non-negative, "
+                f"got {self.contour_slice_count}"
+            )
+        if self.endcap_volume_fraction is not None:
+            validate_in_range(
+                "endcap_volume_fraction", self.endcap_volume_fraction, 0.0, 1.0
+            )
+        if self.computation_time_s is not None:
+            validate_nonneg_finite("computation_time_s", self.computation_time_s)
 
     def to_dict(self) -> dict:
         d: dict = {"contour_slice_count": self.contour_slice_count}
@@ -275,6 +336,11 @@ class ROIResult:
     def __post_init__(self) -> None:
         if isinstance(self.status, str):
             object.__setattr__(self, "status", ROIStatus(self.status))
+        # Coerce lists to tuples for true immutability
+        if isinstance(self.metrics, list):
+            object.__setattr__(self, "metrics", tuple(self.metrics))
+        if isinstance(self.issues, list):
+            object.__setattr__(self, "issues", tuple(self.issues))
 
     def to_dict(self) -> dict:
         d: dict = {
@@ -388,11 +454,22 @@ class ProvenanceRecord:
     platform: PlatformInfo | None = None
 
     def __post_init__(self) -> None:
-        if self.timestamp_utc and not _ISO8601_UTC_RE.match(self.timestamp_utc):
-            raise ValueError(
-                f"timestamp_utc must be ISO 8601 UTC (ending in 'Z'), "
-                f"got '{self.timestamp_utc}'"
-            )
+        if self.timestamp_utc:
+            if not _ISO8601_UTC_RE.match(self.timestamp_utc):
+                raise ValueError(
+                    f"timestamp_utc must be ISO 8601 UTC (ending in 'Z'), "
+                    f"got '{self.timestamp_utc}'"
+                )
+            # Parse to verify it is a valid datetime, not just pattern match
+            try:
+                datetime.datetime.fromisoformat(
+                    self.timestamp_utc.replace("Z", "+00:00")
+                )
+            except ValueError as e:
+                raise ValueError(
+                    f"timestamp_utc is not a valid ISO 8601 datetime: "
+                    f"'{self.timestamp_utc}': {e}"
+                ) from e
 
     def to_dict(self) -> dict:
         d: dict = {
@@ -445,10 +522,12 @@ class DVHResultSet:
                 f"Unsupported schema_version '{self.schema_version}'. "
                 f"Supported: {sorted(_SUPPORTED_SCHEMA_VERSIONS)}"
             )
-        if self.computation_time_s < 0:
-            raise ValueError(
-                f"computation_time_s must be >= 0, got {self.computation_time_s}"
-            )
+        validate_nonneg_finite("computation_time_s", self.computation_time_s)
+        # Coerce lists to tuples for true immutability
+        if isinstance(self.results, list):
+            object.__setattr__(self, "results", tuple(self.results))
+        if isinstance(self.issues, list):
+            object.__setattr__(self, "issues", tuple(self.issues))
 
     def by_name(self, name: str) -> ROIResult:
         """Look up an ROIResult by name.

--- a/lib/pymedphys/_dvh/_types/_results.py
+++ b/lib/pymedphys/_dvh/_types/_results.py
@@ -87,7 +87,9 @@ class DVHBins:
         # A1: Differential volumes must be non-negative
         if np.any(dv < 0):
             raise ValueError("differential_volume_cc values must be non-negative")
-        # A4: Sum of differential volumes must not exceed total volume
+        # A4: Sum of differential volumes must not exceed total volume.
+        # Relative tolerance (1e-9) accommodates floating-point
+        # accumulation error in np.sum.
         dv_sum = float(np.sum(dv))
         if dv_sum > self.total_volume_cc * (1.0 + 1e-9):
             raise ValueError(
@@ -336,6 +338,8 @@ class ROIResult:
     def __post_init__(self) -> None:
         if isinstance(self.status, str):
             object.__setattr__(self, "status", ROIStatus(self.status))
+        if self.volume_cc is not None:
+            validate_nonneg_finite("ROIResult.volume_cc", self.volume_cc)
         # Coerce lists to tuples for true immutability
         if isinstance(self.metrics, list):
             object.__setattr__(self, "metrics", tuple(self.metrics))

--- a/lib/pymedphys/_dvh/_types/_roi_ref.py
+++ b/lib/pymedphys/_dvh/_types/_roi_ref.py
@@ -37,6 +37,11 @@ class ROIRef:
         if not self.name.strip():
             raise ValueError("ROI name must be non-empty")
         if self.colour_rgb is not None:
+            if len(self.colour_rgb) != 3:
+                raise ValueError(
+                    f"colour_rgb must have exactly 3 elements, "
+                    f"got {len(self.colour_rgb)}"
+                )
             for i, c in enumerate(self.colour_rgb):
                 if not (0 <= c <= 255):
                     raise ValueError(

--- a/lib/pymedphys/_dvh/_types/_sdf.py
+++ b/lib/pymedphys/_dvh/_types/_sdf.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._validators import validate_finite_array
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -39,8 +40,7 @@ class SDFField:
         if self.data.shape != expected:
             raise ValueError(f"SDF shape {self.data.shape} != frame shape {expected}")
         d = np.array(self.data, dtype=np.float64)
-        if np.any(~np.isfinite(d)):
-            raise ValueError("SDF values must all be finite (no NaN or Inf)")
+        validate_finite_array("SDFField.data", d, ndim=3)
         d.flags.writeable = False
         object.__setattr__(self, "data", d)
 

--- a/lib/pymedphys/_dvh/_types/_validators.py
+++ b/lib/pymedphys/_dvh/_types/_validators.py
@@ -1,0 +1,143 @@
+"""Shared validators for the DVH type layer.
+
+Provides helpers to reject NaN, Inf, and out-of-range values
+consistently across all domain types.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import numpy.typing as npt
+
+
+def validate_positive_finite(name: str, value: float) -> float:
+    """Validate that *value* is finite and strictly positive.
+
+    Parameters
+    ----------
+    name : str
+        Field name for error messages.
+    value : float
+        Value to check.
+
+    Returns
+    -------
+    float
+        The validated value.
+
+    Raises
+    ------
+    ValueError
+        If *value* is non-finite or <= 0.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
+
+
+def validate_nonneg_finite(name: str, value: float) -> float:
+    """Validate that *value* is finite and non-negative.
+
+    Parameters
+    ----------
+    name : str
+        Field name for error messages.
+    value : float
+        Value to check.
+
+    Returns
+    -------
+    float
+        The validated value.
+
+    Raises
+    ------
+    ValueError
+        If *value* is non-finite or < 0.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+    return value
+
+
+def validate_finite(name: str, value: float) -> float:
+    """Validate that *value* is finite (rejects NaN and Inf).
+
+    Parameters
+    ----------
+    name : str
+        Field name for error messages.
+    value : float
+        Value to check.
+
+    Returns
+    -------
+    float
+        The validated value.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return value
+
+
+def validate_in_range(name: str, value: float, lo: float, hi: float) -> float:
+    """Validate that *value* is finite and in [lo, hi].
+
+    Parameters
+    ----------
+    name : str
+        Field name for error messages.
+    value : float
+        Value to check.
+    lo : float
+        Lower bound (inclusive).
+    hi : float
+        Upper bound (inclusive).
+
+    Returns
+    -------
+    float
+        The validated value.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    if value < lo or value > hi:
+        raise ValueError(f"{name} must be in [{lo}, {hi}], got {value}")
+    return value
+
+
+def validate_finite_array(
+    name: str, arr: npt.NDArray[np.float64], ndim: int | None = None
+) -> npt.NDArray[np.float64]:
+    """Validate that all elements of *arr* are finite.
+
+    Parameters
+    ----------
+    name : str
+        Field name for error messages.
+    arr : numpy array
+        Array to check.
+    ndim : int, optional
+        If given, also validates the array dimensionality.
+
+    Returns
+    -------
+    numpy array
+        The validated array (same object).
+
+    Raises
+    ------
+    ValueError
+        If any element is non-finite or ndim doesn't match.
+    """
+    if ndim is not None and arr.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}D, got {arr.ndim}D")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} contains non-finite values (NaN or Inf)")
+    return arr

--- a/lib/pymedphys/_dvh/_types/_validators.py
+++ b/lib/pymedphys/_dvh/_types/_validators.py
@@ -2,6 +2,10 @@
 
 Provides helpers to reject NaN, Inf, and out-of-range values
 consistently across all domain types.
+
+All scalar validators coerce via ``float()`` for numpy scalar
+compatibility, and return the validated value so callers can use
+``x = validate_positive_finite('x', x)`` patterns.
 """
 
 from __future__ import annotations
@@ -32,6 +36,7 @@ def validate_positive_finite(name: str, value: float) -> float:
     ValueError
         If *value* is non-finite or <= 0.
     """
+    value = float(value)
     if not math.isfinite(value):
         raise ValueError(f"{name} must be finite, got {value!r}")
     if value <= 0:
@@ -59,6 +64,7 @@ def validate_nonneg_finite(name: str, value: float) -> float:
     ValueError
         If *value* is non-finite or < 0.
     """
+    value = float(value)
     if not math.isfinite(value):
         raise ValueError(f"{name} must be finite, got {value!r}")
     if value < 0:
@@ -80,7 +86,13 @@ def validate_finite(name: str, value: float) -> float:
     -------
     float
         The validated value.
+
+    Raises
+    ------
+    ValueError
+        If *value* is non-finite.
     """
+    value = float(value)
     if not math.isfinite(value):
         raise ValueError(f"{name} must be finite, got {value!r}")
     return value
@@ -104,7 +116,13 @@ def validate_in_range(name: str, value: float, lo: float, hi: float) -> float:
     -------
     float
         The validated value.
+
+    Raises
+    ------
+    ValueError
+        If *value* is non-finite or outside [lo, hi].
     """
+    value = float(value)
     if not math.isfinite(value):
         raise ValueError(f"{name} must be finite, got {value!r}")
     if value < lo or value > hi:

--- a/lib/pymedphys/tests/dvh/test_types/test_results.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_results.py
@@ -373,7 +373,7 @@ class TestDVHBinsValidation:
 
     def test_rejects_zero_total_volume(self) -> None:
         """A1: Zero total volume causes division by zero."""
-        with pytest.raises(ValueError, match="strictly positive"):
+        with pytest.raises(ValueError, match="positive"):
             DVHBins(
                 dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
                 differential_volume_cc=np.array([0.0, 0.0]),
@@ -382,7 +382,7 @@ class TestDVHBinsValidation:
 
     def test_rejects_negative_total_volume(self) -> None:
         """A1: Negative total volume is physically meaningless."""
-        with pytest.raises(ValueError, match="strictly positive"):
+        with pytest.raises(ValueError, match="positive"):
             DVHBins(
                 dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
                 differential_volume_cc=np.array([1.0, 1.0]),

--- a/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
@@ -1,0 +1,485 @@
+"""Semantic lock-in tests for Phase 0 type contracts.
+
+These tests explicitly lock down the public semantics that must not
+regress:
+
+- MetricRequestSet canonical round-trip (lossless for duplicate names)
+- Duplicate ROI detection via ROIRef.matches() semantics
+- NaN/Inf rejection across dose refs, config, occupancy, SDF, results
+- Mutation leakage from caller-owned lists/dicts
+- Fixed-axis GridFrame semantics
+- MetricResult.unit validation
+- Timestamp parsing
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from pymedphys._dvh._types._config import (
+    AlgorithmConfig,
+    DVHConfig,
+    PipelinePolicy,
+    RuntimeConfig,
+    SupersamplingConfig,
+)
+from pymedphys._dvh._types._contour import Contour, PlanarRegion
+from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
+from pymedphys._dvh._types._grid_frame import GridFrame
+from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel
+from pymedphys._dvh._types._metrics import (
+    MetricRequestSet,
+    MetricSpec,
+    ROIMetricRequest,
+)
+from pymedphys._dvh._types._occupancy import OccupancyField
+from pymedphys._dvh._types._results import (
+    DVHBins,
+    DVHResultSet,
+    MetricResult,
+    ProvenanceRecord,
+    ROIDiagnostics,
+    ROIResult,
+    ROIStatus,
+)
+from pymedphys._dvh._types._roi_ref import ROIRef
+from pymedphys._dvh._types._sdf import SDFField
+
+
+# ---------------------------------------------------------------------------
+# 1. MetricRequestSet canonical round-trip (Task 1)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricRequestSetCanonicalRoundTrip:
+    """The canonical to_dict() format must be lossless."""
+
+    def test_duplicate_roi_names_different_numbers_survive_round_trip(self) -> None:
+        """Two ROIs with the same name but different roi_numbers must
+        survive a to_dict()/from_dict() round-trip without data loss."""
+        req1 = ROIMetricRequest.from_strings("PTV", ["D95%"], roi_number=1)
+        req2 = ROIMetricRequest.from_strings("PTV", ["mean"], roi_number=2)
+        mrs = MetricRequestSet(roi_requests=(req1, req2))
+        d = mrs.to_dict()
+        restored = MetricRequestSet.from_dict(d)
+        assert len(restored.roi_requests) == 2
+        assert restored.roi_requests[0].roi.name == "PTV"
+        assert restored.roi_requests[0].roi.roi_number == 1
+        assert restored.roi_requests[1].roi.name == "PTV"
+        assert restored.roi_requests[1].roi.roi_number == 2
+
+    def test_metric_metadata_preserved_in_round_trip(self) -> None:
+        """MetricSpec.to_dict() metadata must survive the round-trip."""
+        spec = MetricSpec.parse("D95%")
+        req = ROIMetricRequest(roi=ROIRef(name="PTV"), metrics=(spec,))
+        mrs = MetricRequestSet(roi_requests=(req,))
+        d = mrs.to_dict()
+        restored = MetricRequestSet.from_dict(d)
+        restored_spec = restored.roi_requests[0].metrics[0]
+        assert restored_spec.family == spec.family
+        assert restored_spec.threshold == spec.threshold
+        assert restored_spec.threshold_unit == spec.threshold_unit
+        assert restored_spec.output_unit == spec.output_unit
+
+    def test_repeated_metrics_same_roi_rejected(self) -> None:
+        """Repeated canonical metrics within the same ROI are rejected."""
+        spec = MetricSpec.parse("D95%")
+        with pytest.raises(ValueError, match="Duplicate metrics"):
+            ROIMetricRequest(roi=ROIRef(name="PTV"), metrics=(spec, spec))
+
+    def test_per_roi_dose_ref_id_preserved(self) -> None:
+        """Per-ROI dose_ref_id must survive round-trip."""
+        dose_refs = DoseReferenceSet(
+            refs={"ptv60": DoseReference(dose_gy=60.0, source="prescription dose")},
+            default_id="ptv60",
+        )
+        req = ROIMetricRequest.from_strings("PTV60", ["D95%"], dose_ref_id="ptv60")
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        d = mrs.to_dict()
+        restored = MetricRequestSet.from_dict(d)
+        assert restored.roi_requests[0].dose_ref_id == "ptv60"
+
+    def test_canonical_format_uses_roi_requests_key(self) -> None:
+        """to_dict() must use 'roi_requests', not 'metrics'."""
+        req = ROIMetricRequest.from_strings("PTV", ["mean"])
+        mrs = MetricRequestSet(roi_requests=(req,))
+        d = mrs.to_dict()
+        assert "roi_requests" in d
+        assert "metrics" not in d
+
+    def test_legacy_metrics_format_still_accepted(self) -> None:
+        """from_dict() still accepts the legacy name-keyed format."""
+        d = {
+            "metrics": {
+                "PTV": ["D95%", "mean"],
+                "OAR": ["D0.03cc"],
+            }
+        }
+        mrs = MetricRequestSet.from_dict(d)
+        assert len(mrs.roi_requests) == 2
+
+    def test_from_dict_rejects_missing_both_keys(self) -> None:
+        """from_dict() rejects a dict with neither roi_requests nor metrics."""
+        with pytest.raises(ValueError, match="roi_requests.*metrics"):
+            MetricRequestSet.from_dict({"dose_refs": None})
+
+
+# ---------------------------------------------------------------------------
+# 2. Duplicate ROI detection via ROIRef.matches() (Task 2)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateROIDetection:
+    """Duplicate detection must use ROIRef.matches() semantics."""
+
+    def test_same_name_different_numbers_allowed(self) -> None:
+        """Same name, different roi_number -> distinct ROIs."""
+        req1 = ROIMetricRequest.from_strings("PTV", ["D95%"], roi_number=1)
+        req2 = ROIMetricRequest.from_strings("PTV", ["mean"], roi_number=2)
+        mrs = MetricRequestSet(roi_requests=(req1, req2))
+        assert len(mrs.roi_requests) == 2
+
+    def test_same_number_different_names_rejected(self) -> None:
+        """Same roi_number, different names -> matches() returns True."""
+        req1 = ROIMetricRequest.from_strings("PTV_high", ["D95%"], roi_number=5)
+        req2 = ROIMetricRequest.from_strings("PTV_low", ["mean"], roi_number=5)
+        with pytest.raises(ValueError, match="Duplicate ROI"):
+            MetricRequestSet(roi_requests=(req1, req2))
+
+    def test_same_name_one_numbered_one_not(self) -> None:
+        """Same name, one with roi_number, one without -> matches by name."""
+        req1 = ROIMetricRequest.from_strings("PTV", ["D95%"], roi_number=1)
+        req2 = ROIMetricRequest.from_strings("PTV", ["mean"])
+        with pytest.raises(ValueError, match="Duplicate ROI"):
+            MetricRequestSet(roi_requests=(req1, req2))
+
+    def test_same_name_no_numbers_rejected(self) -> None:
+        """Same name, no numbers -> duplicate."""
+        req1 = ROIMetricRequest.from_strings("PTV", ["D95%"])
+        req2 = ROIMetricRequest.from_strings("PTV", ["mean"])
+        with pytest.raises(ValueError, match="Duplicate ROI"):
+            MetricRequestSet(roi_requests=(req1, req2))
+
+    def test_clearly_distinct_rois(self) -> None:
+        """Completely different ROIs are fine."""
+        req1 = ROIMetricRequest.from_strings("PTV", ["D95%"])
+        req2 = ROIMetricRequest.from_strings("OAR", ["mean"])
+        mrs = MetricRequestSet(roi_requests=(req1, req2))
+        assert len(mrs.roi_requests) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. NaN/Inf rejection (Tasks 4, 8)
+# ---------------------------------------------------------------------------
+
+
+class TestNaNInfRejection:
+    """Non-finite values must be rejected by all domain types."""
+
+    @pytest.fixture()
+    def frame(self) -> GridFrame:
+        return GridFrame.from_uniform(
+            shape_zyx=(2, 2, 2),
+            spacing_mm_xyz=(1.0, 1.0, 1.0),
+        )
+
+    # Dose references
+    def test_dose_ref_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DoseReference(dose_gy=float("nan"), source="test source")
+
+    def test_dose_ref_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DoseReference(dose_gy=float("inf"), source="test source")
+
+    # Config
+    def test_config_dvh_bin_width_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            AlgorithmConfig(dvh_bin_width_gy=float("nan"))
+
+    def test_config_batch_size_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            RuntimeConfig(batch_size_gb=float("inf"))
+
+    def test_config_convergence_tol_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            SupersamplingConfig(adaptive_convergence_tol=float("nan"))
+
+    def test_pipeline_policy_z_tol_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            PipelinePolicy(z_tolerance_mm=float("nan"))
+
+    # Occupancy
+    def test_occupancy_rejects_nan(self, frame: GridFrame) -> None:
+        data = np.full((2, 2, 2), 0.5)
+        data[0, 0, 0] = float("nan")
+        with pytest.raises(ValueError, match="non-finite"):
+            OccupancyField(data=data, frame=frame, roi=ROIRef(name="PTV"))
+
+    def test_occupancy_rejects_inf(self, frame: GridFrame) -> None:
+        data = np.full((2, 2, 2), 0.5)
+        data[0, 0, 0] = float("inf")
+        with pytest.raises(ValueError, match="non-finite|range"):
+            OccupancyField(data=data, frame=frame, roi=ROIRef(name="PTV"))
+
+    # SDF
+    def test_sdf_rejects_nan(self, frame: GridFrame) -> None:
+        data = np.zeros((2, 2, 2))
+        data[0, 0, 0] = float("nan")
+        with pytest.raises(ValueError, match="finite"):
+            SDFField(data=data, frame=frame, roi=ROIRef(name="PTV"))
+
+    # DVH bins
+    def test_dvh_bins_rejects_nan_edges(self) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            DVHBins(
+                dose_bin_edges_gy=np.array([0.0, float("nan"), 2.0]),
+                differential_volume_cc=np.array([1.0, 1.0]),
+                total_volume_cc=5.0,
+            )
+
+    def test_dvh_bins_rejects_inf_total(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DVHBins(
+                dose_bin_edges_gy=np.array([0.0, 1.0, 2.0]),
+                differential_volume_cc=np.array([1.0, 1.0]),
+                total_volume_cc=float("inf"),
+            )
+
+    # MetricResult
+    def test_metric_result_rejects_nan_value(self) -> None:
+        spec = MetricSpec.parse("D95%")
+        with pytest.raises(ValueError, match="finite"):
+            MetricResult(spec=spec, value=float("nan"), unit="Gy")
+
+    def test_metric_result_rejects_inf_convergence(self) -> None:
+        spec = MetricSpec.parse("D95%")
+        with pytest.raises(ValueError, match="finite"):
+            MetricResult(
+                spec=spec,
+                value=50.0,
+                unit="Gy",
+                convergence_estimate=float("inf"),
+            )
+
+    # DVHResultSet
+    def test_result_set_rejects_nan_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            DVHResultSet(
+                schema_version="1.0",
+                results=(),
+                provenance=ProvenanceRecord(),
+                computation_time_s=float("nan"),
+            )
+
+    # GridFrame
+    def test_grid_frame_rejects_nan_in_affine(self) -> None:
+        aff = np.eye(4)
+        aff[0, 3] = float("nan")
+        with pytest.raises(ValueError, match="non-finite"):
+            GridFrame(shape_zyx=(2, 2, 2), index_to_patient_mm=aff)
+
+    # Contour
+    def test_contour_rejects_nan_points(self) -> None:
+        pts = np.array([[0.0, 0.0], [1.0, 0.0], [float("nan"), 1.0]])
+        with pytest.raises(ValueError, match="non-finite"):
+            Contour(points_xy=pts, z_mm=0.0)
+
+
+# ---------------------------------------------------------------------------
+# 4. Mutation leakage from caller-owned containers (Task 5)
+# ---------------------------------------------------------------------------
+
+
+class TestMutationLeakage:
+    """Frozen dataclass internals must not leak caller mutations."""
+
+    def test_dose_ref_set_dict_mutation(self) -> None:
+        """Mutating the caller's dict must not affect DoseReferenceSet."""
+        d = {"rx": DoseReference(dose_gy=60.0, source="prescription dose")}
+        drs = DoseReferenceSet(refs=d, default_id="rx")
+        # Attempt to mutate the caller's dict — should not affect drs
+        d["evil"] = DoseReference(dose_gy=1.0, source="evil source")
+        assert "evil" not in drs.refs
+
+    def test_dose_ref_set_refs_immutable(self) -> None:
+        """DoseReferenceSet.refs must be truly immutable."""
+        drs = DoseReferenceSet.single(dose_gy=60.0, source="prescription dose")
+        with pytest.raises(TypeError):
+            drs.refs["new"] = DoseReference(dose_gy=1.0, source="test ref")  # type: ignore[index]
+
+    def test_roi_metric_request_list_mutation(self) -> None:
+        """Passing a list of metrics, then mutating it, must not leak."""
+        specs = [MetricSpec.parse("D95%"), MetricSpec.parse("mean")]
+        req = ROIMetricRequest(roi=ROIRef(name="PTV"), metrics=specs)  # type: ignore[arg-type]
+        specs.append(MetricSpec.parse("min"))
+        assert len(req.metrics) == 2
+
+    def test_metric_request_set_list_mutation(self) -> None:
+        """Passing a list of roi_requests, then mutating it, must not leak."""
+        req = ROIMetricRequest.from_strings("PTV", ["D95%"])
+        reqs = [req]
+        mrs = MetricRequestSet(roi_requests=reqs)  # type: ignore[arg-type]
+        reqs.append(ROIMetricRequest.from_strings("OAR", ["mean"]))
+        assert len(mrs.roi_requests) == 1
+
+    def test_roi_result_issues_list_mutation(self) -> None:
+        """Passing a list of issues, then mutating it, must not leak."""
+        issue = Issue(
+            level=IssueLevel.WARNING,
+            code=IssueCode.STRUCTURE_VOLUME_SMALL,
+            message="test",
+        )
+        issues = [issue]
+        result = ROIResult(
+            roi=ROIRef(name="PTV"),
+            status=ROIStatus.OK,
+            issues=issues,  # type: ignore[arg-type]
+        )
+        issues.append(issue)
+        assert len(result.issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Fixed-axis GridFrame semantics (Task 6)
+# ---------------------------------------------------------------------------
+
+
+class TestGridFrameAxisContract:
+    """GridFrame enforces fixed (z,y,x) -> (x,y,z) axis mapping."""
+
+    def test_valid_fixed_axis_affine(self) -> None:
+        """Standard HFS affine passes validation."""
+        gf = GridFrame.from_uniform(
+            shape_zyx=(5, 10, 15),
+            spacing_mm_xyz=(2.0, 2.5, 3.0),
+        )
+        assert gf.spacing_mm == (3.0, 2.5, 2.0)  # dz, dy, dx
+
+    def test_valid_sign_flipped_affine(self) -> None:
+        """Negative spacing (sign flips) is allowed."""
+        aff = np.array(
+            [
+                [0.0, 0.0, -1.0, 10.0],
+                [0.0, 2.5, 0.0, -20.0],
+                [3.0, 0.0, 0.0, -30.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+        gf = GridFrame(shape_zyx=(5, 10, 15), index_to_patient_mm=aff)
+        assert gf.shape_zyx == (5, 10, 15)
+
+    def test_rejects_axis_permuted_affine(self) -> None:
+        """Axis permutation (ix->z instead of ix->x) is rejected."""
+        # This affine maps ix->z and iz->x (permutation)
+        aff = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],  # row 0 (patient x) from col 0 (iz)
+                [0.0, 2.5, 0.0, 0.0],  # row 1 (patient y) from col 1 (iy)
+                [0.0, 0.0, 3.0, 0.0],  # row 2 (patient z) from col 2 (ix)
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+        with pytest.raises(ValueError, match="permutation"):
+            GridFrame(shape_zyx=(5, 10, 15), index_to_patient_mm=aff)
+
+    def test_rejects_non_axis_aligned_affine(self) -> None:
+        """Tilted (rotated) affine is rejected."""
+        aff = np.array(
+            [
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 2.5, 0.5, 0.0],  # off-diagonal
+                [3.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
+        with pytest.raises(ValueError, match="axis-aligned"):
+            GridFrame(shape_zyx=(5, 10, 15), index_to_patient_mm=aff)
+
+
+# ---------------------------------------------------------------------------
+# 6. MetricResult.unit validation (Task 8)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricResultUnitValidation:
+    def test_valid_units_accepted(self) -> None:
+        spec = MetricSpec.parse("D95%")
+        for unit in ("Gy", "percent_dose", "cc", "percent_vol", "dimensionless"):
+            MetricResult(spec=spec, value=50.0, unit=unit)
+
+    def test_invalid_unit_rejected(self) -> None:
+        spec = MetricSpec.parse("D95%")
+        with pytest.raises(ValueError, match="unit"):
+            MetricResult(spec=spec, value=50.0, unit="invalid_unit")
+
+
+# ---------------------------------------------------------------------------
+# 7. Timestamp parsing (Task 8)
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampParsing:
+    def test_valid_timestamps(self) -> None:
+        ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00Z")
+        ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00.123Z")
+        ProvenanceRecord(timestamp_utc="")
+
+    def test_rejects_non_utc(self) -> None:
+        with pytest.raises(ValueError):
+            ProvenanceRecord(timestamp_utc="2024-01-15T10:30:00+05:00")
+
+    def test_rejects_malformed(self) -> None:
+        with pytest.raises(ValueError):
+            ProvenanceRecord(timestamp_utc="not-a-timestamp")
+
+    def test_rejects_impossible_date(self) -> None:
+        """Regex passes but datetime parsing should catch invalid date."""
+        with pytest.raises(ValueError):
+            ProvenanceRecord(timestamp_utc="2024-13-45T99:99:99Z")
+
+
+# ---------------------------------------------------------------------------
+# 8. ROIDiagnostics validation (Task 8)
+# ---------------------------------------------------------------------------
+
+
+class TestROIDiagnosticsValidation:
+    def test_rejects_negative_boundary_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ROIDiagnostics(boundary_voxel_count=-1)
+
+    def test_rejects_negative_interior_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ROIDiagnostics(interior_voxel_count=-1)
+
+    def test_rejects_negative_contour_count(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ROIDiagnostics(contour_slice_count=-1)
+
+    def test_rejects_endcap_fraction_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            ROIDiagnostics(endcap_volume_fraction=1.5)
+
+    def test_rejects_nan_computation_time(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            ROIDiagnostics(computation_time_s=float("nan"))
+
+    def test_rejects_nan_gradient(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            ROIDiagnostics(mean_boundary_gradient_gy_per_mm=float("nan"))
+
+    def test_valid_diagnostics(self) -> None:
+        diag = ROIDiagnostics(
+            effective_supersampling=3,
+            boundary_voxel_count=100,
+            interior_voxel_count=500,
+            mean_boundary_gradient_gy_per_mm=0.5,
+            contour_slice_count=10,
+            endcap_volume_fraction=0.05,
+            computation_time_s=1.5,
+        )
+        assert diag.contour_slice_count == 10

--- a/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
@@ -14,19 +14,16 @@ regress:
 
 from __future__ import annotations
 
-import math
-
 import numpy as np
 import pytest
 
 from pymedphys._dvh._types._config import (
     AlgorithmConfig,
-    DVHConfig,
     PipelinePolicy,
     RuntimeConfig,
     SupersamplingConfig,
 )
-from pymedphys._dvh._types._contour import Contour, PlanarRegion
+from pymedphys._dvh._types._contour import Contour
 from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel

--- a/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
@@ -110,6 +110,14 @@ class TestMetricRequestSetCanonicalRoundTrip:
         assert "roi_requests" in d
         assert "metrics" not in d
 
+    def test_omits_none_dose_refs(self) -> None:
+        """to_dict() must not emit dose_refs/default_dose_ref when unset."""
+        req = ROIMetricRequest.from_strings("PTV", ["mean"])
+        mrs = MetricRequestSet(roi_requests=(req,))
+        d = mrs.to_dict()
+        assert "dose_refs" not in d
+        assert "default_dose_ref" not in d
+
     def test_legacy_metrics_format_still_accepted(self) -> None:
         """from_dict() still accepts the legacy name-keyed format."""
         d = {

--- a/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
@@ -31,10 +31,13 @@ from pymedphys._dvh._types._dose_ref import DoseReference, DoseReferenceSet
 from pymedphys._dvh._types._grid_frame import GridFrame
 from pymedphys._dvh._types._issues import Issue, IssueCode, IssueLevel
 from pymedphys._dvh._types._metrics import (
+    MetricFamily,
     MetricRequestSet,
     MetricSpec,
     ROIMetricRequest,
+    ThresholdUnit,
 )
+from pymedphys._dvh._types._dose import DoseGrid
 from pymedphys._dvh._types._occupancy import OccupancyField
 from pymedphys._dvh._types._results import (
     DVHBins,
@@ -491,3 +494,153 @@ class TestROIDiagnosticsValidation:
             computation_time_s=1.5,
         )
         assert diag.contour_slice_count == 10
+
+
+# ---------------------------------------------------------------------------
+# 9. MetricSpec threshold NaN/Inf rejection (review A1)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricSpecThresholdValidation:
+    def test_rejects_nan_threshold(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            MetricSpec(
+                family=MetricFamily.DVH_DOSE,
+                threshold=float("nan"),
+                threshold_unit=ThresholdUnit.PERCENT,
+                raw="test",
+            )
+
+    def test_rejects_inf_threshold(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            MetricSpec(
+                family=MetricFamily.DVH_DOSE,
+                threshold=float("inf"),
+                threshold_unit=ThresholdUnit.PERCENT,
+                raw="test",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 10. DoseGrid NaN/Inf rejection (review A2)
+# ---------------------------------------------------------------------------
+
+
+class TestDoseGridFiniteValidation:
+    @pytest.fixture()
+    def frame(self) -> GridFrame:
+        return GridFrame.from_uniform(
+            shape_zyx=(2, 2, 2),
+            spacing_mm_xyz=(1.0, 1.0, 1.0),
+        )
+
+    def test_rejects_nan_dose(self, frame: GridFrame) -> None:
+        data = np.zeros((2, 2, 2))
+        data[0, 0, 0] = float("nan")
+        with pytest.raises(ValueError, match="non-finite"):
+            DoseGrid(dose_gy=data, frame=frame)
+
+    def test_rejects_inf_dose(self, frame: GridFrame) -> None:
+        data = np.zeros((2, 2, 2))
+        data[0, 0, 0] = float("inf")
+        with pytest.raises(ValueError, match="non-finite"):
+            DoseGrid(dose_gy=data, frame=frame)
+
+    def test_rejects_nan_uncertainty(self, frame: GridFrame) -> None:
+        dose = np.ones((2, 2, 2))
+        unc = np.zeros((2, 2, 2))
+        unc[0, 0, 0] = float("nan")
+        with pytest.raises(ValueError, match="non-finite"):
+            DoseGrid(dose_gy=dose, frame=frame, uncertainty_gy=unc)
+
+
+# ---------------------------------------------------------------------------
+# 11. ROIResult.volume_cc validation (review A3)
+# ---------------------------------------------------------------------------
+
+
+class TestROIResultVolumeValidation:
+    def test_rejects_nan_volume(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            ROIResult(
+                roi=ROIRef(name="PTV"),
+                status=ROIStatus.OK,
+                volume_cc=float("nan"),
+            )
+
+    def test_rejects_negative_volume(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            ROIResult(
+                roi=ROIRef(name="PTV"),
+                status=ROIStatus.OK,
+                volume_cc=-1.0,
+            )
+
+    def test_accepts_zero_volume(self) -> None:
+        r = ROIResult(roi=ROIRef(name="PTV"), status=ROIStatus.OK, volume_cc=0.0)
+        assert r.volume_cc == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 12. Issue.context immutability (review B1)
+# ---------------------------------------------------------------------------
+
+
+class TestIssueContextImmutability:
+    def test_context_mutation_does_not_leak(self) -> None:
+        ctx = {"spacing_mm": 4.0}
+        issue = Issue(
+            level=IssueLevel.WARNING,
+            code=IssueCode.STRUCTURE_VOLUME_SMALL,
+            message="test",
+            context=ctx,
+        )
+        ctx["evil"] = True
+        assert "evil" not in issue.context
+
+    def test_context_is_immutable(self) -> None:
+        issue = Issue(
+            level=IssueLevel.WARNING,
+            code=IssueCode.STRUCTURE_VOLUME_SMALL,
+            message="test",
+            context={"spacing_mm": 4.0},
+        )
+        with pytest.raises(TypeError):
+            issue.context["new_key"] = True  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# 13. MetricRequestSet default_id round-trip (review C5)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricRequestSetDefaultIdRoundTrip:
+    def test_default_id_survives_canonical_round_trip(self) -> None:
+        dose_refs = DoseReferenceSet(
+            refs={
+                "ptv60": DoseReference(dose_gy=60.0, source="prescription dose"),
+                "ptv42": DoseReference(dose_gy=42.0, source="boost prescription"),
+            },
+            default_id="ptv60",
+        )
+        req = ROIMetricRequest.from_strings("PTV60", ["D95%"], dose_ref_id="ptv60")
+        mrs = MetricRequestSet(roi_requests=(req,), dose_refs=dose_refs)
+        d = mrs.to_dict()
+        restored = MetricRequestSet.from_dict(d)
+        assert restored.dose_refs is not None
+        assert restored.dose_refs.default_id == "ptv60"
+
+
+# ---------------------------------------------------------------------------
+# 14. ROIRef colour_rgb length validation (review E2)
+# ---------------------------------------------------------------------------
+
+
+class TestROIRefColourValidation:
+    def test_rejects_too_few_elements(self) -> None:
+        with pytest.raises(ValueError, match="3 elements"):
+            ROIRef(name="PTV", colour_rgb=(255, 0))  # type: ignore[arg-type]
+
+    def test_rejects_too_many_elements(self) -> None:
+        with pytest.raises(ValueError, match="3 elements"):
+            ROIRef(name="PTV", colour_rgb=(255, 0, 0, 128))  # type: ignore[arg-type]

--- a/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_semantic_lockin.py
@@ -596,6 +596,7 @@ class TestIssueContextImmutability:
             context=ctx,
         )
         ctx["evil"] = True
+        assert issue.context is not None
         assert "evil" not in issue.context
 
     def test_context_is_immutable(self) -> None:

--- a/lib/pymedphys/tests/dvh/test_types/test_validators.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_validators.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import numpy as np
 import pytest
 

--- a/lib/pymedphys/tests/dvh/test_types/test_validators.py
+++ b/lib/pymedphys/tests/dvh/test_types/test_validators.py
@@ -1,0 +1,125 @@
+"""Tests for shared validator helpers."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from pymedphys._dvh._types._validators import (
+    validate_finite,
+    validate_finite_array,
+    validate_in_range,
+    validate_nonneg_finite,
+    validate_positive_finite,
+)
+
+
+class TestValidatePositiveFinite:
+    def test_accepts_positive(self) -> None:
+        assert validate_positive_finite("x", 1.0) == 1.0
+
+    def test_rejects_zero(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            validate_positive_finite("x", 0.0)
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="positive"):
+            validate_positive_finite("x", -1.0)
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_positive_finite("x", float("nan"))
+
+    def test_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_positive_finite("x", float("inf"))
+
+    def test_rejects_neg_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_positive_finite("x", float("-inf"))
+
+
+class TestValidateNonnegFinite:
+    def test_accepts_zero(self) -> None:
+        assert validate_nonneg_finite("x", 0.0) == 0.0
+
+    def test_accepts_positive(self) -> None:
+        assert validate_nonneg_finite("x", 5.0) == 5.0
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            validate_nonneg_finite("x", -0.1)
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_nonneg_finite("x", float("nan"))
+
+    def test_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_nonneg_finite("x", float("inf"))
+
+
+class TestValidateFinite:
+    def test_accepts_normal(self) -> None:
+        assert validate_finite("x", 42.0) == 42.0
+
+    def test_accepts_negative(self) -> None:
+        assert validate_finite("x", -1.0) == -1.0
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_finite("x", float("nan"))
+
+    def test_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_finite("x", float("inf"))
+
+
+class TestValidateInRange:
+    def test_accepts_in_range(self) -> None:
+        assert validate_in_range("x", 0.5, 0.0, 1.0) == 0.5
+
+    def test_accepts_boundaries(self) -> None:
+        assert validate_in_range("x", 0.0, 0.0, 1.0) == 0.0
+        assert validate_in_range("x", 1.0, 0.0, 1.0) == 1.0
+
+    def test_rejects_below(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            validate_in_range("x", -0.1, 0.0, 1.0)
+
+    def test_rejects_above(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            validate_in_range("x", 1.1, 0.0, 1.0)
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            validate_in_range("x", float("nan"), 0.0, 1.0)
+
+
+class TestValidateFiniteArray:
+    def test_accepts_finite(self) -> None:
+        arr = np.array([1.0, 2.0, 3.0])
+        result = validate_finite_array("a", arr)
+        assert result is arr
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            validate_finite_array("a", np.array([1.0, float("nan"), 3.0]))
+
+    def test_rejects_inf(self) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            validate_finite_array("a", np.array([float("inf"), 2.0]))
+
+    def test_rejects_neg_inf(self) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            validate_finite_array("a", np.array([float("-inf")]))
+
+    def test_validates_ndim(self) -> None:
+        with pytest.raises(ValueError, match="2D"):
+            validate_finite_array("a", np.array([1.0, 2.0]), ndim=2)
+
+    def test_accepts_correct_ndim(self) -> None:
+        arr = np.array([[1.0, 2.0]])
+        validate_finite_array("a", arr, ndim=2)


### PR DESCRIPTION
## Summary

Implements comprehensive semantic lock-in tests and validation for the DVH type layer (Phase 0), ensuring that critical contracts around serialisation, duplicate detection, NaN/Inf rejection, immutability, and axis semantics are enforced and cannot regress.

## Why

Phase 0 establishes the foundational type contracts that all downstream phases depend on. This PR:

1. **Prevents regressions** by explicitly testing the public semantics that must not change
2. **Enforces data integrity** by validating non-finite values (NaN, Inf) across all domain types
3. **Guarantees immutability** by coercing caller-owned lists to tuples and using `MappingProxyType`
4. **Clarifies serialisation** by establishing a canonical lossless format for `MetricRequestSet`
5. **Fixes duplicate detection** to use `ROIRef.matches()` semantics (same roi_number OR same name when unnumbered)
6. **Validates axis semantics** in `GridFrame` to prevent axis permutation or rotation

Closes #<issue_number>

## What changed

- **New test file** `test_semantic_lockin.py`: 485 lines of semantic lock-in tests covering:
  - `MetricRequestSet` canonical round-trip (lossless for duplicate names)
  - Duplicate ROI detection via `ROIRef.matches()` semantics
  - NaN/Inf rejection across dose refs, config, occupancy, SDF, results
  - Mutation leakage from caller-owned lists/dicts
  - Fixed-axis `GridFrame` semantics
  - `MetricResult.unit` validation
  - Timestamp parsing in `ProvenanceRecord`
  - `ROIDiagnostics` field validation

- **New validator module** `_validators.py`: Shared helpers for consistent NaN/Inf/range validation:
  - `validate_positive_finite()`, `validate_nonneg_finite()`, `validate_finite()`
  - `validate_in_range()`, `validate_finite_array()`

- **Updated `_metrics.py`**:
  - Coerce `metrics` list to tuple in `ROIMetricRequest.__post_init__()`
  - Coerce `roi_requests` list to tuple in `MetricRequestSet.__post_init__()`
  - Fix duplicate detection to use `ROIRef.matches()` instead of separate name/number checks
  - Rewrite `to_dict()` to emit canonical lossless format with explicit `roi_requests`
  - Enhance `from_dict()` to accept both canonical and legacy formats

- **Updated `_results.py`**:
  - Add NaN/Inf validation to `DVHBins`, `MetricResult`, `ROIDiagnostics`, `DVHResultSet`
  - Validate `MetricResult.unit` against `OutputUnit` enum
  - Add timestamp parsing validation to `ProvenanceRecord`
  - Coerce `issues` list to tuple in `MetricResult.__post_init__()`

- **Updated `_config.py`**:
  - Use `validate_positive_finite()` for `SupersamplingConfig.adaptive_convergence_tol`
  - Use `validate_positive_finite()` for `RuntimeConfig.batch_size_gb`
  - Use `validate_positive_finite()` for `PipelinePolicy.z_tolerance_mm`

- **Updated `_dose_ref.py`**:
  - Use `validate_positive_finite()` for `DoseReference.dose_gy`
  - Wrap `refs` dict in `MappingProxyType` for true immutability

- **Updated `_grid_frame.py`**:
  - Add `validate_finite_array()` check for affine matrix
  - Clarify axis-aligned validation to enforce fixed semantic mapping (iz→z, iy→y, ix→x)
  - Reject axis permutation while allowing sign flips

- **Updated `_occupancy.py`**:
  - Add `validate_finite_array()` check for occupancy data

- **Updated `_contour

https://claude.ai/code/session_01Uqhn2Kggqoxq7AVHLeYbNz

## Summary by Sourcery

Lock down DVH type-layer semantics with stronger validation, canonical serialization, and immutability guarantees across metric requests, results, geometry, and configuration.

New Features:
- Introduce shared validator helpers for finite, non-negative, positive, range-checked scalars and arrays used across DVH domain types.
- Add semantic lock-in test suite covering DVH types’ serialization, NaN/Inf handling, immutability, ROI duplicate detection, axis semantics, and diagnostics validation.

Bug Fixes:
- Correct MetricRequestSet duplicate ROI detection to follow ROIRef.matches() semantics, preventing incorrect acceptance or rejection of ROIs.

Enhancements:
- Make DVH metric request and result containers truly immutable by coercing caller-supplied lists to tuples and wrapping dose reference mappings in MappingProxyType.
- Define a canonical, lossless MetricRequestSet serialization format using explicit roi_requests while retaining backwards-compatible support for the legacy metrics format.
- Strengthen DVH geometry and diagnostics validation, including fixed-axis GridFrame semantics, ROIDiagnostics field constraints, MetricResult unit validation, and stricter timestamp parsing in ProvenanceRecord.
- Enforce consistent NaN/Inf and range validation across dose references, DVH bins, occupancy, SDF fields, contours, config values, and result metadata.

Tests:
- Add comprehensive semantic lock-in tests for DVH types, verifying canonical round-trips, immutability, NaN/Inf rejection, ROI duplicate rules, axis contracts, units, timestamps, and diagnostics constraints.